### PR TITLE
Initialize CMake scaffolding and sample config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.24)
+project(LizardTapper LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_subdirectory(src/app)
+add_subdirectory(src/hook)
+add_subdirectory(src/audio)
+add_subdirectory(src/overlay)
+add_subdirectory(src/util)
+add_subdirectory(src/platform)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,34 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 24, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "linux",
+      "displayName": "Linux",
+      "generator": "Ninja",
+      "binaryDir": "build/linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "macos",
+      "displayName": "macOS",
+      "generator": "Ninja",
+      "binaryDir": "build/macos",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "win-mingw",
+      "displayName": "Windows MinGW",
+      "generator": "Ninja",
+      "binaryDir": "build/win-mingw",
+      "toolchainFile": "cmake/toolchains/mingw.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ]
+}

--- a/cmake/toolchains/mingw.cmake
+++ b/cmake/toolchains/mingw.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)

--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -1,0 +1,16 @@
+{
+  "enabled": true,
+  "mute": false,
+  "sound_cooldown_ms": 150,
+  "max_concurrent_playbacks": 16,
+  "badges_per_second_max": 12,
+  "badge_min_px": 60,
+  "badge_max_px": 108,
+  "emoji": ["🦎"],
+  "fullscreen_pause": true,
+  "exclude_processes": [],
+  "ignore_injected": true,
+  "audio_backend": "miniaudio",
+  "fps_mode": "auto",
+  "fps_fixed": 60
+}

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_app INTERFACE)

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_audio INTERFACE)

--- a/src/hook/CMakeLists.txt
+++ b/src/hook/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_hook INTERFACE)

--- a/src/overlay/CMakeLists.txt
+++ b/src/overlay/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_overlay INTERFACE)

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(lizard_platform INTERFACE)
+
+add_subdirectory(win)
+add_subdirectory(mac)
+add_subdirectory(linux)

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_platform_linux INTERFACE)

--- a/src/platform/mac/CMakeLists.txt
+++ b/src/platform/mac/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_platform_mac INTERFACE)

--- a/src/platform/win/CMakeLists.txt
+++ b/src/platform/win/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_platform_win INTERFACE)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(lizard_util INTERFACE)


### PR DESCRIPTION
## Summary
- scaffold C++20 project with top-level CMake and stub module directories
- add cross-platform `CMakePresets.json` including MinGW toolchain
- include empty `VERSION` and sample `lizard.json` config

## Testing
- `cmake --preset linux`
- `cmake --preset win-mingw`
- `cmake --preset macos`


------
https://chatgpt.com/codex/tasks/task_e_689b4adc80648325a946bdd68496773b