### PR TITLE
Add miniaudio engine with FLAC preload and backend selection

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -1,1 +1,46 @@
-add_library(lizard_audio INTERFACE)
+include(FetchContent)
+
+FetchContent_Declare(
+  miniaudio
+  GIT_REPOSITORY https://github.com/mackron/miniaudio.git
+  GIT_TAG        master
+)
+
+FetchContent_Declare(
+  drflac
+  GIT_REPOSITORY https://github.com/mackron/dr_libs.git
+  GIT_TAG        master
+)
+
+FetchContent_MakeAvailable(miniaudio drflac)
+
+add_library(lizard_audio STATIC engine.cpp)
+
+target_include_directories(lizard_audio
+  PRIVATE
+    ${miniaudio_SOURCE_DIR}
+    ${drflac_SOURCE_DIR}
+)
+
+set(AUDIO_BACKEND "ALSA" CACHE STRING "Audio backend (WASAPI, CoreAudio, ALSA)")
+set_property(CACHE AUDIO_BACKEND PROPERTY STRINGS WASAPI CoreAudio ALSA)
+
+if(AUDIO_BACKEND STREQUAL "WASAPI")
+  target_compile_definitions(lizard_audio PRIVATE LIZARD_AUDIO_WASAPI)
+elseif(AUDIO_BACKEND STREQUAL "CoreAudio")
+  target_compile_definitions(lizard_audio PRIVATE LIZARD_AUDIO_COREAUDIO)
+elseif(AUDIO_BACKEND STREQUAL "ALSA")
+  target_compile_definitions(lizard_audio PRIVATE LIZARD_AUDIO_ALSA)
+endif()
+
+# Link platform specific libraries
+if(AUDIO_BACKEND STREQUAL "WASAPI")
+  target_link_libraries(lizard_audio PRIVATE ole32 uuid)
+elif(AUDIO_BACKEND STREQUAL "CoreAudio")
+  find_library(COREAUDIO_LIB CoreAudio)
+  find_library(AUDIOTOOLBOX_LIB AudioToolbox)
+  target_link_libraries(lizard_audio PRIVATE ${COREAUDIO_LIB} ${AUDIOTOOLBOX_LIB})
+elif(AUDIO_BACKEND STREQUAL "ALSA")
+  target_link_libraries(lizard_audio PRIVATE asound)
+endif()
+

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -1,0 +1,135 @@
+#include <algorithm>
+#include <chrono>
+#include <optional>
+#include <string>
+#include <vector>
+
+#if defined(LIZARD_AUDIO_WASAPI)
+#define MA_ENABLE_WASAPI
+#elif defined(LIZARD_AUDIO_COREAUDIO)
+#define MA_ENABLE_COREAUDIO
+#elif defined(LIZARD_AUDIO_ALSA)
+#define MA_ENABLE_ALSA
+#endif
+
+#define MINIAUDIO_IMPLEMENTATION
+#include "miniaudio.h"
+
+#define DR_FLAC_IMPLEMENTATION
+#include "dr_flac.h"
+
+namespace lizard::audio {
+
+namespace {
+struct DecodedSample {
+  std::vector<float> pcm;
+  ma_uint64 frames = 0;
+  ma_uint32 channels = 0;
+  ma_uint32 sampleRate = 0;
+};
+
+std::optional<DecodedSample> load_flac(const std::string &path) {
+  drflac *flac = drflac_open_file(path.c_str(), nullptr);
+  if (flac == nullptr) {
+    return std::nullopt;
+  }
+
+  DecodedSample sample;
+  sample.frames = flac->totalPCMFrameCount;
+  sample.channels = flac->channels;
+  sample.sampleRate = flac->sampleRate;
+  sample.pcm.resize(sample.frames * sample.channels);
+  drflac_read_pcm_frames_f32(flac, sample.frames, sample.pcm.data());
+  drflac_close(flac);
+  return sample;
+}
+} // namespace
+
+class Engine {
+public:
+  Engine(std::uint32_t maxPlaybacks, std::chrono::milliseconds cooldown)
+      : m_maxPlaybacks(maxPlaybacks), m_cooldown(cooldown) {}
+
+  ~Engine() { shutdown(); }
+
+  bool init() {
+    ma_result result = ma_engine_init(nullptr, &m_engine);
+    if (result != MA_SUCCESS) {
+      return false;
+    }
+
+    auto decoded = load_flac("assets/lizard.flac");
+    if (!decoded) {
+      ma_engine_uninit(&m_engine);
+      return false;
+    }
+
+    m_bufferConfig = ma_audio_buffer_config_init(
+        ma_format_f32, decoded->channels, decoded->frames, decoded->pcm.data(),
+        nullptr);
+    result = ma_audio_buffer_init(&m_bufferConfig, &m_buffer);
+    if (result != MA_SUCCESS) {
+      ma_engine_uninit(&m_engine);
+      return false;
+    }
+
+    m_voices.resize(m_maxPlaybacks);
+    for (auto &voice : m_voices) {
+      ma_sound_init_from_data_source(&m_engine, &m_buffer, 0, nullptr,
+                                     &voice.sound);
+    }
+    return true;
+  }
+
+  void shutdown() {
+    for (auto &voice : m_voices) {
+      ma_sound_uninit(&voice.sound);
+    }
+    m_voices.clear();
+    ma_audio_buffer_uninit(&m_buffer);
+    ma_engine_uninit(&m_engine);
+  }
+
+  void play() {
+    auto now = std::chrono::steady_clock::now();
+    if ((now - m_lastPlay) < m_cooldown) {
+      return;
+    }
+    m_lastPlay = now;
+
+    Voice *target = nullptr;
+    for (auto &voice : m_voices) {
+      if (!ma_sound_is_playing(&voice.sound)) {
+        target = &voice;
+        break;
+      }
+    }
+
+    if (target == nullptr) {
+      target = &*std::min_element(
+          m_voices.begin(), m_voices.end(),
+          [](const Voice &a, const Voice &b) { return a.start < b.start; });
+      ma_sound_stop(&target->sound);
+    }
+
+    ma_sound_seek_to_pcm_frame(&target->sound, 0);
+    ma_sound_start(&target->sound);
+    target->start = now;
+  }
+
+private:
+  struct Voice {
+    ma_sound sound{};
+    std::chrono::steady_clock::time_point start{};
+  };
+
+  ma_engine m_engine{};
+  ma_audio_buffer_config m_bufferConfig{};
+  ma_audio_buffer m_buffer{};
+  std::vector<Voice> m_voices;
+  std::uint32_t m_maxPlaybacks = 0;
+  std::chrono::steady_clock::time_point m_lastPlay{};
+  std::chrono::milliseconds m_cooldown{};
+};
+
+} // namespace lizard::audio

--- a/third_party/fetch_audio_deps.sh
+++ b/third_party/fetch_audio_deps.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+DIR="$(dirname "$0")"
+cd "$DIR"
+
+if [ ! -d "miniaudio" ]; then
+  git clone --depth 1 https://github.com/mackron/miniaudio.git
+fi
+
+if [ ! -d "dr_libs" ]; then
+  git clone --depth 1 https://github.com/mackron/dr_libs.git
+fi


### PR DESCRIPTION
## Summary
- preload assets/lizard.flac with dr_flac and play it through miniaudio
- cap concurrent playbacks with LRU drop and cooldown enforcement
- fetch miniaudio/dr_flac at configure time and enable WASAPI/CoreAudio/ALSA backends

## Testing
- `clang-format --dry-run src/audio/engine.cpp`
- `cmake -S . -B build`
- `cmake --build build` *(fails: X11/extensions/XInput2.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689b59ee12748325854847185e6847de