### PR TITLE
feat: add OpenGL overlay and platform helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,51 @@
 cmake_minimum_required(VERSION 3.24)
-project(LizardTapper LANGUAGES CXX)
+project(LizardTapper LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(FetchContent)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Fetch and build glad
+FetchContent_Declare(
+  glad
+  GIT_REPOSITORY https://github.com/Dav1dde/glad.git
+  GIT_TAG v0.1.36
+)
+FetchContent_GetProperties(glad)
+if(NOT glad_POPULATED)
+  FetchContent_Populate(glad)
+endif()
+set(GLAD_GEN_DIR ${CMAKE_BINARY_DIR}/glad)
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -m glad --profile core --api gl=3.3 --generator c --out-path ${GLAD_GEN_DIR}
+  WORKING_DIRECTORY ${glad_SOURCE_DIR}
+  RESULT_VARIABLE glad_result
+)
+if(NOT glad_result EQUAL 0)
+  message(FATAL_ERROR "glad generation failed")
+endif()
+add_library(glad STATIC ${GLAD_GEN_DIR}/src/glad.c)
+target_include_directories(glad PUBLIC ${GLAD_GEN_DIR}/include)
+
+# Fetch stb
+FetchContent_Declare(
+  stb
+  GIT_REPOSITORY https://github.com/nothings/stb.git
+  GIT_TAG master
+)
+FetchContent_GetProperties(stb)
+if(NOT stb_POPULATED)
+  FetchContent_Populate(stb)
+endif()
+add_library(stb_image INTERFACE)
+target_include_directories(stb_image INTERFACE ${stb_SOURCE_DIR})
+
 add_subdirectory(src/app)
 add_subdirectory(src/hook)
 add_subdirectory(src/audio)
+add_subdirectory(src/platform)
 add_subdirectory(src/overlay)
 add_subdirectory(src/util)
-add_subdirectory(src/platform)

--- a/src/overlay/CMakeLists.txt
+++ b/src/overlay/CMakeLists.txt
@@ -1,1 +1,8 @@
-add_library(lizard_overlay INTERFACE)
+add_library(lizard_overlay overlay.cpp)
+
+target_include_directories(lizard_overlay
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(lizard_overlay PUBLIC lizard_platform glad stb_image)

--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -1,0 +1,236 @@
+#include "platform/window.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "glad/glad.h"
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+namespace lizard::overlay {
+
+struct Sprite {
+  float u0;
+  float v0;
+  float u1;
+  float v1;
+};
+
+struct Badge {
+  float x;
+  float y;
+  float scale;
+  float alpha;
+  float time;
+  float lifetime;
+  int sprite;
+};
+
+class Overlay {
+public:
+  bool init();
+  void shutdown();
+  void spawn_badge(int sprite, float x, float y);
+  void run();
+
+private:
+  void update(float dt);
+  void render();
+
+  platform::Window m_window{};
+  std::vector<Badge> m_badges;
+  std::vector<Sprite> m_sprites;
+  GLuint m_texture = 0;
+  GLuint m_vao = 0;
+  GLuint m_vbo = 0;
+  GLuint m_instance = 0;
+  GLuint m_program = 0;
+  bool m_running = false;
+};
+
+// Embedded 1x1 PNG placeholder
+static const unsigned char atlas_png[] = {
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x04, 0x00, 0x00, 0x00, 0xb5, 0x1c, 0x0c, 0x02, 0x00, 0x00, 0x00,
+    0x0b, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+    0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82};
+
+bool Overlay::init() {
+  platform::WindowDesc desc{800, 600};
+  m_window = platform::create_overlay_window(desc);
+  if (!m_window.native) {
+    return false;
+  }
+
+  // Load atlas
+  int w, h, channels;
+  unsigned char *pixels =
+      stbi_load_from_memory(atlas_png, sizeof(atlas_png), &w, &h, &channels, 4);
+  if (!pixels) {
+    return false;
+  }
+  glGenTextures(1, &m_texture);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+               pixels);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  stbi_image_free(pixels);
+
+  // single sprite covering full texture
+  m_sprites.push_back({0.0f, 0.0f, 1.0f, 1.0f});
+
+  // Geometry
+  const float verts[] = {-0.5f, -0.5f, 0.0f, 0.0f, 0.5f,  -0.5f, 1.0f, 0.0f,
+                         0.5f,  0.5f,  1.0f, 1.0f, -0.5f, 0.5f,  0.0f, 1.0f};
+  glGenVertexArrays(1, &m_vao);
+  glBindVertexArray(m_vao);
+  glGenBuffers(1, &m_vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
+
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)0);
+  glEnableVertexAttribArray(1);
+  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
+                        (void *)(2 * sizeof(float)));
+
+  glGenBuffers(1, &m_instance);
+  glBindBuffer(GL_ARRAY_BUFFER, m_instance);
+  glBufferData(GL_ARRAY_BUFFER, 1000 * sizeof(float) * 6, nullptr,
+               GL_DYNAMIC_DRAW);
+  glEnableVertexAttribArray(2);
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void *)0);
+  glVertexAttribDivisor(2, 1);
+  glEnableVertexAttribArray(3);
+  glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, 6 * sizeof(float),
+                        (void *)(2 * sizeof(float)));
+  glVertexAttribDivisor(3, 1);
+  glEnableVertexAttribArray(4);
+  glVertexAttribPointer(4, 2, GL_FLOAT, GL_FALSE, 6 * sizeof(float),
+                        (void *)(4 * sizeof(float)));
+  glVertexAttribDivisor(4, 1);
+
+  const char *vs = R"GLSL(
+      #version 330 core
+      layout(location=0) in vec2 inPos;
+      layout(location=1) in vec2 inUV;
+      layout(location=2) in vec2 iPos;
+      layout(location=3) in vec2 iScale;
+      layout(location=4) in vec2 iUV;
+      out vec2 uv;
+      void main(){
+        vec2 pos = inPos * iScale + iPos;
+        gl_Position = vec4(pos,0.0,1.0);
+        uv = inUV * iUV;
+      })GLSL";
+  const char *fs = R"GLSL(
+      #version 330 core
+      in vec2 uv;
+      out vec4 color;
+      uniform sampler2D uTex;
+      uniform float uAlpha;
+      void main(){
+        color = texture(uTex, uv) * uAlpha;
+      })GLSL";
+  GLuint vsId = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(vsId, 1, &vs, nullptr);
+  glCompileShader(vsId);
+  GLuint fsId = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(fsId, 1, &fs, nullptr);
+  glCompileShader(fsId);
+  m_program = glCreateProgram();
+  glAttachShader(m_program, vsId);
+  glAttachShader(m_program, fsId);
+  glLinkProgram(m_program);
+  glDeleteShader(vsId);
+  glDeleteShader(fsId);
+
+  m_running = true;
+  return true;
+}
+
+void Overlay::shutdown() {
+  if (m_texture) {
+    glDeleteTextures(1, &m_texture);
+    m_texture = 0;
+  }
+  platform::destroy_window(m_window);
+}
+
+void Overlay::spawn_badge(int sprite, float x, float y) {
+  Badge b{};
+  b.x = x;
+  b.y = y;
+  b.scale = 0.1f;
+  b.alpha = 1.0f;
+  b.time = 0.0f;
+  b.lifetime = 1.0f;
+  b.sprite = sprite;
+  m_badges.push_back(b);
+}
+
+void Overlay::update(float dt) {
+  for (auto &b : m_badges) {
+    b.time += dt;
+    float t = b.time / b.lifetime;
+    b.alpha = 1.0f - t;
+    b.scale = 0.1f + 0.1f * t;
+  }
+  m_badges.erase(
+      std::remove_if(m_badges.begin(), m_badges.end(),
+                     [](const Badge &b) { return b.time >= b.lifetime; }),
+      m_badges.end());
+}
+
+void Overlay::render() {
+  glClearColor(0, 0, 0, 0);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  std::vector<float> data;
+  for (const auto &b : m_badges) {
+    const Sprite &s = m_sprites[b.sprite];
+    data.push_back(b.x);
+    data.push_back(b.y);
+    data.push_back(b.scale);
+    data.push_back(b.scale);
+    data.push_back(s.u1 - s.u0);
+    data.push_back(s.v1 - s.v0);
+  }
+  glBindBuffer(GL_ARRAY_BUFFER, m_instance);
+  glBufferSubData(GL_ARRAY_BUFFER, 0, data.size() * sizeof(float), data.data());
+
+  glUseProgram(m_program);
+  glBindVertexArray(m_vao);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+  for (const auto &b : m_badges) {
+    glUniform1f(glGetUniformLocation(m_program, "uAlpha"), b.alpha);
+    glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, 1);
+  }
+  platform::poll_events(m_window);
+}
+
+void Overlay::run() {
+  using clock = std::chrono::steady_clock;
+  const auto frame = std::chrono::milliseconds(16);
+  auto last = clock::now();
+  while (m_running) {
+    auto now = clock::now();
+    float dt = std::chrono::duration<float>(now - last).count();
+    last = now;
+    update(dt);
+    render();
+    auto end = clock::now();
+    auto spend = end - now;
+    if (spend < frame) {
+      std::this_thread::sleep_for(frame - spend);
+    }
+  }
+}
+
+} // namespace lizard::overlay

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -1,5 +1,14 @@
 add_library(lizard_platform INTERFACE)
 
-add_subdirectory(win)
-add_subdirectory(mac)
-add_subdirectory(linux)
+target_include_directories(lizard_platform INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(WIN32)
+  add_subdirectory(win)
+  target_link_libraries(lizard_platform INTERFACE lizard_platform_win)
+elif(APPLE)
+  add_subdirectory(mac)
+  target_link_libraries(lizard_platform INTERFACE lizard_platform_mac)
+else()
+  add_subdirectory(linux)
+  target_link_libraries(lizard_platform INTERFACE lizard_platform_linux)
+endif()

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_library(lizard_platform_linux INTERFACE)
+add_library(lizard_platform_linux window.cpp)
+
+target_include_directories(lizard_platform_linux PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+
+target_link_libraries(lizard_platform_linux PUBLIC X11 Xfixes Xext GL glad)

--- a/src/platform/linux/window.cpp
+++ b/src/platform/linux/window.cpp
@@ -1,0 +1,118 @@
+#include "../window.hpp"
+
+#include "glad/glad.h"
+#include <GL/glx.h>
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/Xfixes.h>
+#include <X11/extensions/shape.h>
+
+namespace lizard::platform {
+
+namespace {
+
+Display *g_display = nullptr;
+::Window g_root = 0;
+
+float compute_dpi(Display *dpy, ::Window win) {
+  int screen = DefaultScreen(dpy);
+  int width_px = DisplayWidth(dpy, screen);
+  int width_mm = DisplayWidthMM(dpy, screen);
+  float dpi =
+      static_cast<float>(width_px) / static_cast<float>(width_mm) * 25.4f;
+  return dpi / 96.0f;
+}
+
+} // namespace
+
+Window create_overlay_window(const WindowDesc &desc) {
+  Window result{};
+  g_display = XOpenDisplay(nullptr);
+  if (!g_display) {
+    return result;
+  }
+  int screen = DefaultScreen(g_display);
+  g_root = RootWindow(g_display, screen);
+
+  XSetWindowAttributes attrs{};
+  attrs.override_redirect = True;
+  attrs.event_mask = StructureNotifyMask;
+  attrs.background_pixel = 0;
+
+  ::Window win =
+      XCreateWindow(g_display, g_root, 0, 0, desc.width, desc.height, 0,
+                    CopyFromParent, InputOutput, CopyFromParent,
+                    CWOverrideRedirect | CWEventMask | CWBackPixel, &attrs);
+
+  XMapRaised(g_display, win);
+
+  // Click-through using shape extension
+  XserverRegion region = XFixesCreateRegion(g_display, nullptr, 0);
+  XFixesSetWindowShapeRegion(g_display, win, ShapeInput, 0, 0, region);
+  XFixesDestroyRegion(g_display, region);
+
+  GLXFBConfig fb = nullptr;
+  int nfb = 0;
+  int attrsList[] = {GLX_RENDER_TYPE,
+                     GLX_RGBA_BIT,
+                     GLX_DRAWABLE_TYPE,
+                     GLX_WINDOW_BIT,
+                     GLX_DOUBLEBUFFER,
+                     True,
+                     GLX_RED_SIZE,
+                     8,
+                     GLX_GREEN_SIZE,
+                     8,
+                     GLX_BLUE_SIZE,
+                     8,
+                     GLX_ALPHA_SIZE,
+                     8,
+                     None};
+  GLXFBConfig *configs = glXChooseFBConfig(g_display, screen, attrsList, &nfb);
+  if (configs && nfb > 0) {
+    fb = configs[0];
+    XFree(configs);
+  }
+  using CreateContext =
+      GLXContext (*)(Display *, GLXFBConfig, GLXContext, Bool, const int *);
+  auto createContext = (CreateContext)glXGetProcAddress(
+      (const GLubyte *)"glXCreateContextAttribsARB");
+  int ctxAttr[] = {GLX_CONTEXT_MAJOR_VERSION_ARB,
+                   3,
+                   GLX_CONTEXT_MINOR_VERSION_ARB,
+                   3,
+                   GLX_CONTEXT_PROFILE_MASK_ARB,
+                   GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+                   None};
+  GLXContext ctx = nullptr;
+  if (createContext) {
+    ctx = createContext(g_display, fb, nullptr, True, ctxAttr);
+  }
+  glXMakeCurrent(g_display, win, ctx);
+  gladLoadGL();
+
+  result.native = (void *)win;
+  result.dpiScale = compute_dpi(g_display, win);
+  return result;
+}
+
+void destroy_window(Window &window) {
+  if (g_display && window.native) {
+    glXMakeCurrent(g_display, None, nullptr);
+    XDestroyWindow(g_display, (::Window)window.native);
+    XCloseDisplay(g_display);
+  }
+  window.native = nullptr;
+}
+
+void poll_events(Window &window) {
+  if (!g_display || !window.native) {
+    return;
+  }
+  while (XPending(g_display)) {
+    XEvent ev;
+    XNextEvent(g_display, &ev);
+  }
+}
+
+} // namespace lizard::platform

--- a/src/platform/mac/CMakeLists.txt
+++ b/src/platform/mac/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_library(lizard_platform_mac INTERFACE)
+add_library(lizard_platform_mac window.mm)
+
+target_include_directories(lizard_platform_mac PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+
+target_link_libraries(lizard_platform_mac PUBLIC "-framework Cocoa" "-framework OpenGL")

--- a/src/platform/mac/window.mm
+++ b/src/platform/mac/window.mm
@@ -1,0 +1,61 @@
+#include "../window.hpp"
+
+#ifdef __APPLE__
+#include <Cocoa/Cocoa.h>
+
+namespace lizard::platform {
+
+namespace {
+NSWindow *g_window = nil;
+
+float compute_dpi(NSWindow *w) {
+  NSScreen *screen = [w screen];
+  CGFloat dpi = [screen backingScaleFactor] * 96.0;
+  return dpi / 96.0f;
+}
+} // namespace
+
+Window create_overlay_window(const WindowDesc &desc) {
+  Window result{};
+  @autoreleasepool {
+    NSUInteger style = NSWindowStyleMaskBorderless;
+    g_window = [[NSWindow alloc]
+        initWithContentRect:NSMakeRect(0, 0, desc.width, desc.height)
+                  styleMask:style
+                    backing:NSBackingStoreBuffered
+                      defer:NO];
+    [g_window setLevel:NSStatusWindowLevel];
+    [g_window setOpaque:NO];
+    [g_window setIgnoresMouseEvents:YES];
+    [g_window makeKeyAndOrderFront:nil];
+    result.native = g_window;
+    result.dpiScale = compute_dpi(g_window);
+  }
+  return result;
+}
+
+void destroy_window(Window &window) {
+  @autoreleasepool {
+    if (g_window) {
+      [g_window close];
+      g_window = nil;
+    }
+    window.native = nullptr;
+  }
+}
+
+void poll_events(Window &window) {
+  @autoreleasepool {
+    NSEvent *event;
+    while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                       untilDate:[NSDate distantPast]
+                                          inMode:NSDefaultRunLoopMode
+                                         dequeue:YES])) {
+      [NSApp sendEvent:event];
+    }
+  }
+}
+
+} // namespace lizard::platform
+
+#endif

--- a/src/platform/win/CMakeLists.txt
+++ b/src/platform/win/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_library(lizard_platform_win INTERFACE)
+add_library(lizard_platform_win window.cpp)
+
+target_include_directories(lizard_platform_win PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+
+target_link_libraries(lizard_platform_win PUBLIC user32 gdi32 opengl32 dwmapi glad)

--- a/src/platform/win/window.cpp
+++ b/src/platform/win/window.cpp
@@ -1,0 +1,80 @@
+#include "../window.hpp"
+
+#ifdef _WIN32
+#include "glad/glad.h"
+#include <dwmapi.h>
+#include <windows.h>
+#pragma comment(lib, "dwmapi.lib")
+
+namespace lizard::platform {
+
+namespace {
+HWND g_hwnd = nullptr;
+
+float compute_dpi(HWND hwnd) {
+  UINT dpi = GetDpiForWindow(hwnd);
+  return dpi / 96.0f;
+}
+
+LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
+  return DefWindowProc(hwnd, msg, wp, lp);
+}
+} // namespace
+
+Window create_overlay_window(const WindowDesc &desc) {
+  Window result{};
+  HINSTANCE inst = GetModuleHandle(nullptr);
+  WNDCLASSW wc{};
+  wc.hInstance = inst;
+  wc.lpfnWndProc = wnd_proc;
+  wc.lpszClassName = L"LizardOverlay";
+  RegisterClassW(&wc);
+
+  DWORD exStyle = WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST |
+                  WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+  g_hwnd =
+      CreateWindowExW(exStyle, wc.lpszClassName, L"", WS_POPUP, 0, 0,
+                      desc.width, desc.height, nullptr, nullptr, inst, nullptr);
+  if (!g_hwnd) {
+    return result;
+  }
+  MARGINS margins{-1};
+  DwmExtendFrameIntoClientArea(g_hwnd, &margins);
+  ShowWindow(g_hwnd, SW_SHOW);
+
+  PIXELFORMATDESCRIPTOR pfd{};
+  pfd.nSize = sizeof(pfd);
+  pfd.nVersion = 1;
+  pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+  pfd.iPixelType = PFD_TYPE_RGBA;
+  pfd.cColorBits = 32;
+  HDC dc = GetDC(g_hwnd);
+  int pf = ChoosePixelFormat(dc, &pfd);
+  SetPixelFormat(dc, pf, &pfd);
+  HGLRC rc = wglCreateContext(dc);
+  wglMakeCurrent(dc, rc);
+  gladLoadGL();
+
+  result.native = g_hwnd;
+  result.dpiScale = compute_dpi(g_hwnd);
+  return result;
+}
+
+void destroy_window(Window &window) {
+  if (window.native) {
+    DestroyWindow((HWND)window.native);
+  }
+  window.native = nullptr;
+}
+
+void poll_events(Window &window) {
+  MSG msg;
+  while (PeekMessage(&msg, (HWND)window.native, 0, 0, PM_REMOVE)) {
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
+}
+
+} // namespace lizard::platform
+
+#endif

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lizard::platform {
+
+struct WindowDesc {
+  std::uint32_t width;
+  std::uint32_t height;
+};
+
+struct Window {
+  void *native = nullptr;
+  float dpiScale = 1.0f;
+};
+
+Window create_overlay_window(const WindowDesc &desc);
+void destroy_window(Window &window);
+void poll_events(Window &window);
+
+} // namespace lizard::platform


### PR DESCRIPTION
## Summary
- create cross-platform window helpers with DPI awareness for Linux, Windows, and macOS
- implement OpenGL overlay rendering badges from an embedded PNG atlas
- fetch glad and stb_image at configure time and link them statically

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/platform/window.hpp src/platform/linux/window.cpp src/platform/win/window.cpp src/platform/mac/window.mm`
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `clang-tidy src/overlay/overlay.cpp -- -std=c++20 -Ibuild/glad/include -Ibuild/_deps/stb-src -Isrc` (warnings in stb_image.h)


------
https://chatgpt.com/codex/tasks/task_e_689b61375b7c83259ff66e0c0f7a166b