### PR TITLE
Add cross-platform system tray with menu actions

### DIFF
--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -1,5 +1,21 @@
-add_library(lizard_platform_linux window.cpp)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+pkg_check_modules(APPINDICATOR ayatana-appindicator3-0.1 QUIET)
 
-target_include_directories(lizard_platform_linux PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+add_library(lizard_platform_linux window.cpp tray.cpp)
 
-target_link_libraries(lizard_platform_linux PUBLIC X11 Xfixes Xext GL glad)
+target_include_directories(lizard_platform_linux PUBLIC
+  ${CMAKE_CURRENT_LIST_DIR}/..
+  ${GTK3_INCLUDE_DIRS}
+  ${APPINDICATOR_INCLUDE_DIRS}
+)
+
+target_link_libraries(lizard_platform_linux PUBLIC
+  X11 Xfixes Xext GL glad
+  ${GTK3_LIBRARIES}
+  ${APPINDICATOR_LIBRARIES}
+)
+
+if(APPINDICATOR_FOUND)
+  target_compile_definitions(lizard_platform_linux PRIVATE LIZARD_HAVE_APPINDICATOR)
+endif()

--- a/src/platform/linux/tray.cpp
+++ b/src/platform/linux/tray.cpp
@@ -1,0 +1,170 @@
+#include "../tray.hpp"
+
+#ifndef __APPLE__
+#ifndef _WIN32
+
+#if __has_include(<libayatana-appindicator/app-indicator.h>)
+#define LIZARD_HAVE_APPINDICATOR 1
+#include <libayatana-appindicator/app-indicator.h>
+#elif __has_include(<libappindicator/app-indicator.h>)
+#define LIZARD_HAVE_APPINDICATOR 1
+#include <libappindicator/app-indicator.h>
+#endif
+
+#include <gtk/gtk.h>
+
+namespace lizard::platform {
+
+namespace {
+TrayState g_state;
+TrayCallbacks g_callbacks;
+GtkWidget *g_menu = nullptr;
+GtkWidget *g_item_enabled = nullptr;
+GtkWidget *g_item_mute = nullptr;
+GtkWidget *g_item_fullscreen = nullptr;
+GtkWidget *g_item_fps = nullptr;
+GtkWidget *g_item_config = nullptr;
+GtkWidget *g_item_logs = nullptr;
+GtkWidget *g_item_quit = nullptr;
+#ifdef LIZARD_HAVE_APPINDICATOR
+AppIndicator *g_indicator = nullptr;
+#else
+GtkStatusIcon *g_status_icon = nullptr;
+#endif
+
+void update_menu() {
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_enabled),
+                                 g_state.enabled);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_mute),
+                                 g_state.muted);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fullscreen),
+                                 g_state.fullscreen_pause);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps),
+                                 g_state.show_fps);
+}
+
+void on_enabled(GtkWidget *, gpointer) {
+  g_state.enabled = !g_state.enabled;
+  if (g_callbacks.toggle_enabled)
+    g_callbacks.toggle_enabled(g_state.enabled);
+  update_menu();
+}
+void on_mute(GtkWidget *, gpointer) {
+  g_state.muted = !g_state.muted;
+  if (g_callbacks.toggle_mute)
+    g_callbacks.toggle_mute(g_state.muted);
+  update_menu();
+}
+void on_fullscreen(GtkWidget *, gpointer) {
+  g_state.fullscreen_pause = !g_state.fullscreen_pause;
+  if (g_callbacks.toggle_fullscreen_pause)
+    g_callbacks.toggle_fullscreen_pause(g_state.fullscreen_pause);
+  update_menu();
+}
+void on_fps(GtkWidget *, gpointer) {
+  g_state.show_fps = !g_state.show_fps;
+  if (g_callbacks.toggle_fps)
+    g_callbacks.toggle_fps(g_state.show_fps);
+  update_menu();
+}
+void on_config(GtkWidget *, gpointer) {
+  if (g_callbacks.open_config)
+    g_callbacks.open_config();
+}
+void on_logs(GtkWidget *, gpointer) {
+  if (g_callbacks.open_logs)
+    g_callbacks.open_logs();
+}
+void on_quit(GtkWidget *, gpointer) {
+  if (g_callbacks.quit)
+    g_callbacks.quit();
+}
+#ifndef LIZARD_HAVE_APPINDICATOR
+void on_popup(GtkStatusIcon *, guint button, guint activate_time, gpointer) {
+  gtk_menu_popup_at_pointer(GTK_MENU(g_menu), nullptr);
+}
+#endif
+
+} // namespace
+
+bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
+  g_state = state;
+  g_callbacks = callbacks;
+  int argc = 0;
+  char **argv = nullptr;
+  gtk_init(&argc, &argv);
+
+  g_menu = gtk_menu_new();
+  g_item_enabled = gtk_check_menu_item_new_with_label("Enabled");
+  g_signal_connect(g_item_enabled, "activate", G_CALLBACK(on_enabled), nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_enabled);
+  g_item_mute = gtk_check_menu_item_new_with_label("Mute");
+  g_signal_connect(g_item_mute, "activate", G_CALLBACK(on_mute), nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_mute);
+  g_item_fullscreen = gtk_check_menu_item_new_with_label("Pause in Fullscreen");
+  g_signal_connect(g_item_fullscreen, "activate", G_CALLBACK(on_fullscreen),
+                   nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_fullscreen);
+  g_item_fps = gtk_check_menu_item_new_with_label("Show FPS");
+  g_signal_connect(g_item_fps, "activate", G_CALLBACK(on_fps), nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_fps);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), gtk_separator_menu_item_new());
+  g_item_config = gtk_menu_item_new_with_label("Open Config");
+  g_signal_connect(g_item_config, "activate", G_CALLBACK(on_config), nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_config);
+  g_item_logs = gtk_menu_item_new_with_label("Open Logs");
+  g_signal_connect(g_item_logs, "activate", G_CALLBACK(on_logs), nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_logs);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), gtk_separator_menu_item_new());
+  g_item_quit = gtk_menu_item_new_with_label("Quit");
+  g_signal_connect(g_item_quit, "activate", G_CALLBACK(on_quit), nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_quit);
+  gtk_widget_show_all(g_menu);
+
+#ifdef LIZARD_HAVE_APPINDICATOR
+  g_indicator = app_indicator_new("lizard", "indicator-messages",
+                                  APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+  app_indicator_set_menu(g_indicator, GTK_MENU(g_menu));
+  app_indicator_set_status(g_indicator, APP_INDICATOR_STATUS_ACTIVE);
+#else
+  g_status_icon = gtk_status_icon_new_from_icon_name("indicator-messages");
+  g_signal_connect(g_status_icon, "popup-menu", G_CALLBACK(on_popup), nullptr);
+  gtk_status_icon_set_visible(g_status_icon, TRUE);
+  gtk_status_icon_set_has_tooltip(g_status_icon, TRUE);
+  gtk_status_icon_set_tooltip_text(g_status_icon, "Lizard Tapper");
+  gtk_status_icon_set_title(g_status_icon, "Lizard Tapper");
+  gtk_status_icon_set_name(g_status_icon, "lizard");
+  gtk_status_icon_set_from_icon_name(g_status_icon, "indicator-messages");
+#endif
+
+  update_menu();
+  return true;
+}
+
+void update_tray(const TrayState &state) {
+  g_state = state;
+  update_menu();
+}
+
+void shutdown_tray() {
+#ifdef LIZARD_HAVE_APPINDICATOR
+  if (g_indicator) {
+    app_indicator_set_status(g_indicator, APP_INDICATOR_STATUS_PASSIVE);
+    g_indicator = nullptr;
+  }
+#else
+  if (g_status_icon) {
+    g_object_unref(G_OBJECT(g_status_icon));
+    g_status_icon = nullptr;
+  }
+#endif
+  if (g_menu) {
+    gtk_widget_destroy(g_menu);
+    g_menu = nullptr;
+  }
+}
+
+} // namespace lizard::platform
+
+#endif
+#endif

--- a/src/platform/mac/CMakeLists.txt
+++ b/src/platform/mac/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_library(lizard_platform_mac window.mm)
+add_library(lizard_platform_mac window.mm tray.mm)
 
-target_include_directories(lizard_platform_mac PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+    target_include_directories(
+        lizard_platform_mac PUBLIC ${CMAKE_CURRENT_LIST_DIR} /..)
 
-target_link_libraries(lizard_platform_mac PUBLIC "-framework Cocoa" "-framework OpenGL")
+        target_link_libraries(lizard_platform_mac PUBLIC "-framework Cocoa"
+                                                         "-framework OpenGL")

--- a/src/platform/mac/tray.mm
+++ b/src/platform/mac/tray.mm
@@ -1,0 +1,152 @@
+#include "../tray.hpp"
+
+#ifdef __APPLE__
+#import <Cocoa/Cocoa.h>
+
+namespace lizard::platform {
+
+namespace {
+TrayState g_state;
+TrayCallbacks g_callbacks;
+NSStatusItem *g_item = nil;
+NSMenu *g_menu = nil;
+NSMenuItem *g_enabled = nil;
+NSMenuItem *g_mute = nil;
+NSMenuItem *g_fullscreen = nil;
+NSMenuItem *g_fps = nil;
+
+@interface TrayTarget : NSObject
+@end
+
+@implementation TrayTarget
+- (void)toggleEnabled:(id)sender {
+  g_state.enabled = !g_state.enabled;
+  if (g_callbacks.toggle_enabled)
+    g_callbacks.toggle_enabled(g_state.enabled);
+  [g_enabled setState:g_state.enabled ? NSControlStateValueOn
+                                      : NSControlStateValueOff];
+}
+- (void)toggleMute:(id)sender {
+  g_state.muted = !g_state.muted;
+  if (g_callbacks.toggle_mute)
+    g_callbacks.toggle_mute(g_state.muted);
+  [g_mute
+      setState:g_state.muted ? NSControlStateValueOn : NSControlStateValueOff];
+}
+- (void)toggleFullscreen:(id)sender {
+  g_state.fullscreen_pause = !g_state.fullscreen_pause;
+  if (g_callbacks.toggle_fullscreen_pause)
+    g_callbacks.toggle_fullscreen_pause(g_state.fullscreen_pause);
+  [g_fullscreen setState:g_state.fullscreen_pause ? NSControlStateValueOn
+                                                  : NSControlStateValueOff];
+}
+- (void)toggleFPS:(id)sender {
+  g_state.show_fps = !g_state.show_fps;
+  if (g_callbacks.toggle_fps)
+    g_callbacks.toggle_fps(g_state.show_fps);
+  [g_fps setState:g_state.show_fps ? NSControlStateValueOn
+                                   : NSControlStateValueOff];
+}
+- (void)openConfig:(id)sender {
+  if (g_callbacks.open_config)
+    g_callbacks.open_config();
+}
+- (void)openLogs:(id)sender {
+  if (g_callbacks.open_logs)
+    g_callbacks.open_logs();
+}
+- (void)quit:(id)sender {
+  if (g_callbacks.quit)
+    g_callbacks.quit();
+}
+@end
+
+TrayTarget *g_target = nil;
+
+void rebuild_menu() {
+  [g_enabled setState:g_state.enabled ? NSControlStateValueOn
+                                      : NSControlStateValueOff];
+  [g_mute
+      setState:g_state.muted ? NSControlStateValueOn : NSControlStateValueOff];
+  [g_fullscreen setState:g_state.fullscreen_pause ? NSControlStateValueOn
+                                                  : NSControlStateValueOff];
+  [g_fps setState:g_state.show_fps ? NSControlStateValueOn
+                                   : NSControlStateValueOff];
+}
+
+} // namespace
+
+bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
+  g_state = state;
+  g_callbacks = callbacks;
+  @autoreleasepool {
+    g_target = [TrayTarget new];
+    g_item = [[NSStatusBar systemStatusBar]
+        statusItemWithLength:NSVariableStatusItemLength];
+    [g_item.button setTitle:@"🦎"];
+    g_menu = [[NSMenu alloc] initWithTitle:@""];
+    g_enabled = [[NSMenuItem alloc] initWithTitle:@"Enabled"
+                                           action:@selector(toggleEnabled:)
+                                    keyEquivalent:@""];
+    [g_enabled setTarget:g_target];
+    g_mute = [[NSMenuItem alloc] initWithTitle:@"Mute"
+                                        action:@selector(toggleMute:)
+                                 keyEquivalent:@""];
+    [g_mute setTarget:g_target];
+    g_fullscreen =
+        [[NSMenuItem alloc] initWithTitle:@"Pause in Fullscreen"
+                                   action:@selector(toggleFullscreen:)
+                            keyEquivalent:@""];
+    [g_fullscreen setTarget:g_target];
+    g_fps = [[NSMenuItem alloc] initWithTitle:@"Show FPS"
+                                       action:@selector(toggleFPS:)
+                                keyEquivalent:@""];
+    [g_fps setTarget:g_target];
+    NSMenuItem *cfg = [[NSMenuItem alloc] initWithTitle:@"Open Config"
+                                                 action:@selector(openConfig:)
+                                          keyEquivalent:@""];
+    [cfg setTarget:g_target];
+    NSMenuItem *logs = [[NSMenuItem alloc] initWithTitle:@"Open Logs"
+                                                  action:@selector(openLogs:)
+                                           keyEquivalent:@""];
+    [logs setTarget:g_target];
+    NSMenuItem *quit = [[NSMenuItem alloc] initWithTitle:@"Quit"
+                                                  action:@selector(quit:)
+                                           keyEquivalent:@""];
+    [quit setTarget:g_target];
+    [g_menu addItem:g_enabled];
+    [g_menu addItem:g_mute];
+    [g_menu addItem:g_fullscreen];
+    [g_menu addItem:g_fps];
+    [g_menu addItem:[NSMenuItem separatorItem]];
+    [g_menu addItem:cfg];
+    [g_menu addItem:logs];
+    [g_menu addItem:[NSMenuItem separatorItem]];
+    [g_menu addItem:quit];
+    [g_item setMenu:g_menu];
+    rebuild_menu();
+  }
+  return true;
+}
+
+void update_tray(const TrayState &state) {
+  g_state = state;
+  @autoreleasepool {
+    rebuild_menu();
+  }
+}
+
+void shutdown_tray() {
+  @autoreleasepool {
+    if (g_item) {
+      [[NSStatusBar systemStatusBar] removeStatusItem:g_item];
+      g_item = nil;
+    }
+    g_menu = nil;
+    g_target = nil;
+  }
+}
+
+} // namespace lizard::platform
+
+#endif

--- a/src/platform/tray.hpp
+++ b/src/platform/tray.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <functional>
+
+namespace lizard::platform {
+
+struct TrayState {
+  bool enabled = true;
+  bool muted = false;
+  bool fullscreen_pause = false;
+  bool show_fps = false;
+};
+
+struct TrayCallbacks {
+  std::function<void(bool)> toggle_enabled;
+  std::function<void(bool)> toggle_mute;
+  std::function<void(bool)> toggle_fullscreen_pause;
+  std::function<void(bool)> toggle_fps;
+  std::function<void()> open_config;
+  std::function<void()> open_logs;
+  std::function<void()> quit;
+};
+
+bool init_tray(const TrayState &state, const TrayCallbacks &callbacks);
+void update_tray(const TrayState &state);
+void shutdown_tray();
+
+} // namespace lizard::platform

--- a/src/platform/win/CMakeLists.txt
+++ b/src/platform/win/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_library(lizard_platform_win window.cpp)
+add_library(lizard_platform_win window.cpp tray.cpp)
 
-target_include_directories(lizard_platform_win PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+    target_include_directories(
+        lizard_platform_win PUBLIC ${CMAKE_CURRENT_LIST_DIR} /..)
 
-target_link_libraries(lizard_platform_win PUBLIC user32 gdi32 opengl32 dwmapi glad)
+        target_link_libraries(lizard_platform_win PUBLIC user32 gdi32 opengl32
+                                  dwmapi shell32 glad)

--- a/src/platform/win/tray.cpp
+++ b/src/platform/win/tray.cpp
@@ -1,0 +1,148 @@
+#include "../tray.hpp"
+
+#ifdef _WIN32
+#include <shellapi.h>
+#include <windows.h>
+
+namespace lizard::platform {
+
+namespace {
+TrayState g_state;
+TrayCallbacks g_callbacks;
+HWND g_hwnd = nullptr;
+HMENU g_menu = nullptr;
+NOTIFYICONDATAW g_nid{};
+constexpr UINT WM_TRAY = WM_APP + 1;
+
+enum MenuId {
+  ID_ENABLED = 1,
+  ID_MUTE,
+  ID_FULLSCREEN,
+  ID_FPS,
+  ID_CONFIG,
+  ID_LOGS,
+  ID_QUIT,
+};
+
+void update_menu() {
+  CheckMenuItem(g_menu, ID_ENABLED,
+                MF_BYCOMMAND | (g_state.enabled ? MF_CHECKED : MF_UNCHECKED));
+  CheckMenuItem(g_menu, ID_MUTE,
+                MF_BYCOMMAND | (g_state.muted ? MF_CHECKED : MF_UNCHECKED));
+  CheckMenuItem(g_menu, ID_FULLSCREEN,
+                MF_BYCOMMAND |
+                    (g_state.fullscreen_pause ? MF_CHECKED : MF_UNCHECKED));
+  CheckMenuItem(g_menu, ID_FPS,
+                MF_BYCOMMAND | (g_state.show_fps ? MF_CHECKED : MF_UNCHECKED));
+}
+
+void on_command(UINT id) {
+  switch (id) {
+  case ID_ENABLED:
+    g_state.enabled = !g_state.enabled;
+    if (g_callbacks.toggle_enabled)
+      g_callbacks.toggle_enabled(g_state.enabled);
+    update_menu();
+    break;
+  case ID_MUTE:
+    g_state.muted = !g_state.muted;
+    if (g_callbacks.toggle_mute)
+      g_callbacks.toggle_mute(g_state.muted);
+    update_menu();
+    break;
+  case ID_FULLSCREEN:
+    g_state.fullscreen_pause = !g_state.fullscreen_pause;
+    if (g_callbacks.toggle_fullscreen_pause)
+      g_callbacks.toggle_fullscreen_pause(g_state.fullscreen_pause);
+    update_menu();
+    break;
+  case ID_FPS:
+    g_state.show_fps = !g_state.show_fps;
+    if (g_callbacks.toggle_fps)
+      g_callbacks.toggle_fps(g_state.show_fps);
+    update_menu();
+    break;
+  case ID_CONFIG:
+    if (g_callbacks.open_config)
+      g_callbacks.open_config();
+    break;
+  case ID_LOGS:
+    if (g_callbacks.open_logs)
+      g_callbacks.open_logs();
+    break;
+  case ID_QUIT:
+    if (g_callbacks.quit)
+      g_callbacks.quit();
+    break;
+  }
+}
+
+LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+  if (msg == WM_COMMAND) {
+    on_command(LOWORD(wParam));
+  } else if (msg == WM_TRAY) {
+    if (lParam == WM_RBUTTONUP || lParam == WM_CONTEXTMENU) {
+      POINT pt;
+      GetCursorPos(&pt);
+      SetForegroundWindow(hwnd);
+      TrackPopupMenu(g_menu, TPM_RIGHTBUTTON, pt.x, pt.y, 0, hwnd, nullptr);
+    }
+  }
+  return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+} // namespace
+
+bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
+  g_state = state;
+  g_callbacks = callbacks;
+
+  WNDCLASSW wc{};
+  wc.lpfnWndProc = wnd_proc;
+  wc.hInstance = GetModuleHandle(nullptr);
+  wc.lpszClassName = L"LizardTray";
+  RegisterClassW(&wc);
+  g_hwnd = CreateWindowW(wc.lpszClassName, L"", 0, 0, 0, 0, 0, HWND_MESSAGE,
+                         nullptr, wc.hInstance, nullptr);
+
+  g_menu = CreatePopupMenu();
+  AppendMenuW(g_menu, MF_STRING, ID_ENABLED, L"Enabled");
+  AppendMenuW(g_menu, MF_STRING, ID_MUTE, L"Mute");
+  AppendMenuW(g_menu, MF_STRING, ID_FULLSCREEN, L"Pause in Fullscreen");
+  AppendMenuW(g_menu, MF_STRING, ID_FPS, L"Show FPS");
+  AppendMenuW(g_menu, MF_SEPARATOR, 0, nullptr);
+  AppendMenuW(g_menu, MF_STRING, ID_CONFIG, L"Open Config");
+  AppendMenuW(g_menu, MF_STRING, ID_LOGS, L"Open Logs");
+  AppendMenuW(g_menu, MF_SEPARATOR, 0, nullptr);
+  AppendMenuW(g_menu, MF_STRING, ID_QUIT, L"Quit");
+  update_menu();
+
+  g_nid.cbSize = sizeof(g_nid);
+  g_nid.hWnd = g_hwnd;
+  g_nid.uID = 1;
+  g_nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+  g_nid.uCallbackMessage = WM_TRAY;
+  g_nid.hIcon = LoadIcon(nullptr, IDI_APPLICATION);
+  lstrcpyW(g_nid.szTip, L"Lizard Tapper");
+  Shell_NotifyIconW(NIM_ADD, &g_nid);
+  return true;
+}
+
+void update_tray(const TrayState &state) {
+  g_state = state;
+  update_menu();
+}
+
+void shutdown_tray() {
+  Shell_NotifyIconW(NIM_DELETE, &g_nid);
+  if (g_menu)
+    DestroyMenu(g_menu);
+  g_menu = nullptr;
+  if (g_hwnd)
+    DestroyWindow(g_hwnd);
+  g_hwnd = nullptr;
+}
+
+} // namespace lizard::platform
+
+#endif


### PR DESCRIPTION
## Summary
- add common tray interface with callbacks for toggling features
- implement Windows Shell_NotifyIcon tray with menu actions
- implement macOS NSStatusItem tray and Linux AppIndicator/GTK tray

## Testing
- `clang-format --dry-run -Werror src/platform/tray.hpp src/platform/win/tray.cpp src/platform/mac/tray.mm src/platform/linux/tray.cpp`
- `clang-tidy src/platform/linux/tray.cpp -p build --quiet`
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689b8bb55180832583588a51261e3d5f