### PR TITLE
feat: add JSON-configured settings loader

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_library(lizard_app INTERFACE)
+add_library(lizard_app STATIC
+    config.cpp
+)
+
+target_include_directories(lizard_app PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -1,0 +1,124 @@
+#include "config.h"
+
+#include <cstdlib>
+#include <fstream>
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace lizard::app {
+
+Config::Config(std::filesystem::path executable_dir,
+               std::optional<std::filesystem::path> cli_path) {
+  if (cli_path && std::filesystem::exists(*cli_path)) {
+    config_path_ = *cli_path;
+  } else {
+    auto user_path = user_config_path();
+    if (std::filesystem::exists(user_path)) {
+      config_path_ = user_path;
+    } else {
+      config_path_ = executable_dir / "lizard.json";
+    }
+  }
+
+  load();
+  if (std::filesystem::exists(config_path_)) {
+    last_write_ = std::filesystem::last_write_time(config_path_);
+  }
+
+  watcher_ = std::jthread([this](std::stop_token st) {
+    using namespace std::chrono_literals;
+    while (!st.stop_requested()) {
+      std::this_thread::sleep_for(1s);
+      if (!std::filesystem::exists(config_path_)) {
+        continue;
+      }
+      auto current = std::filesystem::last_write_time(config_path_);
+      if (current != last_write_) {
+        last_write_ = current;
+        load();
+      }
+    }
+  });
+}
+
+Config::~Config() { watcher_.request_stop(); }
+
+std::filesystem::path Config::user_config_path() {
+#ifdef _WIN32
+  if (auto *local = std::getenv("LOCALAPPDATA")) {
+    return std::filesystem::path(local) / "LizardTapper" / "lizard.json";
+  }
+#elif __APPLE__
+  if (auto *home = std::getenv("HOME")) {
+    return std::filesystem::path(home) / "Library" / "Application Support" /
+           "LizardTapper" / "lizard.json";
+  }
+#else
+  if (auto *xdg = std::getenv("XDG_CONFIG_HOME")) {
+    return std::filesystem::path(xdg) / "lizard_tapper" / "lizard.json";
+  }
+  if (auto *home = std::getenv("HOME")) {
+    return std::filesystem::path(home) / ".config" / "lizard_tapper" /
+           "lizard.json";
+  }
+#endif
+  return {};
+}
+
+void Config::load() {
+  std::ifstream in(config_path_);
+  if (!in.is_open()) {
+    return; // keep defaults
+  }
+
+  try {
+    json j;
+    in >> j;
+
+    enabled_ = j.value("enabled", true);
+    mute_ = j.value("mute", false);
+    sound_cooldown_ms_ = j.value("sound_cooldown_ms", 150);
+    max_concurrent_playbacks_ = j.value("max_concurrent_playbacks", 4);
+    badges_per_second_max_ = j.value("badges_per_second_max", 12);
+    badge_min_px_ = j.value("badge_min_px", 60);
+    badge_max_px_ = j.value("badge_max_px", 108);
+    fullscreen_pause_ = j.value("fullscreen_pause", true);
+    exclude_processes_ =
+        j.value("exclude_processes", std::vector<std::string>{});
+    ignore_injected_ = j.value("ignore_injected", true);
+    audio_backend_ = j.value("audio_backend", std::string("miniaudio"));
+    badge_spawn_strategy_ =
+        j.value("badge_spawn_strategy", std::string("random_screen"));
+    volume_percent_ = j.value("volume_percent", 65);
+    dpi_scaling_mode_ =
+        j.value("dpi_scaling_mode", std::string("per_monitor_v2"));
+    logging_level_ = j.value("logging_level", std::string("info"));
+
+    if (j.contains("emoji_weighted")) {
+      emoji_weighted_.clear();
+      for (auto &[k, v] : j.at("emoji_weighted").items()) {
+        emoji_weighted_[k] = v.get<double>();
+      }
+      emoji_.clear();
+    } else {
+      emoji_ = j.value("emoji", std::vector<std::string>{"\U0001F98E"});
+      emoji_weighted_.clear();
+    }
+  } catch (const std::exception &) {
+    // keep defaults on parse errors
+  }
+}
+
+bool Config::enabled() const { return enabled_; }
+
+bool Config::mute() const { return mute_; }
+
+const std::vector<std::string> &Config::emoji() const { return emoji_; }
+
+const std::unordered_map<std::string, double> &Config::emoji_weighted() const {
+  return emoji_weighted_;
+}
+
+} // namespace lizard::app

--- a/src/app/config.h
+++ b/src/app/config.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+namespace lizard::app {
+
+class Config {
+public:
+  Config(std::filesystem::path executable_dir,
+         std::optional<std::filesystem::path> cli_path = std::nullopt);
+  ~Config();
+
+  bool enabled() const;
+  bool mute() const;
+  const std::vector<std::string> &emoji() const;
+  const std::unordered_map<std::string, double> &emoji_weighted() const;
+
+private:
+  void load();
+  static std::filesystem::path user_config_path();
+
+  std::filesystem::path config_path_;
+  std::filesystem::file_time_type last_write_{};
+  std::jthread watcher_;
+
+  // config values
+  bool enabled_{true};
+  bool mute_{false};
+  int sound_cooldown_ms_{150};
+  int max_concurrent_playbacks_{4};
+  int badges_per_second_max_{12};
+  int badge_min_px_{60};
+  int badge_max_px_{108};
+  std::vector<std::string> emoji_{"\U0001F98E"};
+  std::unordered_map<std::string, double> emoji_weighted_{};
+  bool fullscreen_pause_{true};
+  std::vector<std::string> exclude_processes_{};
+  bool ignore_injected_{true};
+  std::string audio_backend_{"miniaudio"};
+  std::string badge_spawn_strategy_{"random_screen"};
+  int volume_percent_{65};
+  std::string dpi_scaling_mode_{"per_monitor_v2"};
+  std::string logging_level_{"info"};
+};
+
+} // namespace lizard::app


### PR DESCRIPTION
## Summary
- add config loader using nlohmann::json with default values
- watch `lizard.json` for changes and reload automatically
- expose getters for enabled, mute, and emoji selections

## Testing
- `clang-format --dry-run src/app/config.cpp src/app/config.h`
- `clang-tidy src/app/config.cpp -- -std=c++20` *(fails: 'nlohmann/json.hpp' file not found)*
- `cmake -S . -B build -G Ninja` *(fails: Package 'gtk+-3.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b936e85888325bb03a5aa5806f22b