### PR TITLE
Add Catch2 tests and lint tooling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 2
+ColumnLimit: 100

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: '-*,bugprone-*,modernize-*,readability-*'
+HeaderFilterRegex: 'src/.*'
+FormatStyle: none

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,12 @@ project(LizardTapper LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(FetchContent)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-# Fetch and build glad
+#Fetch and build glad
 FetchContent_Declare(
   glad
   GIT_REPOSITORY https://github.com/Dav1dde/glad.git
@@ -30,7 +31,7 @@ endif()
 add_library(glad STATIC ${GLAD_GEN_DIR}/src/glad.c)
 target_include_directories(glad PUBLIC ${GLAD_GEN_DIR}/include)
 
-# Fetch stb
+#Fetch stb
 FetchContent_Declare(
   stb
   GIT_REPOSITORY https://github.com/nothings/stb.git
@@ -43,9 +44,35 @@ endif()
 add_library(stb_image INTERFACE)
 target_include_directories(stb_image INTERFACE ${stb_SOURCE_DIR})
 
+#Fetch nlohmann_json
+FetchContent_Declare(
+  nlohmann_json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG v3.11.2
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 add_subdirectory(src/app)
 add_subdirectory(src/hook)
 add_subdirectory(src/audio)
 add_subdirectory(src/platform)
 add_subdirectory(src/overlay)
 add_subdirectory(src/util)
+
+include(CTest)
+if(BUILD_TESTING)
+  FetchContent_Declare(
+    catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.5.2
+  )
+  FetchContent_MakeAvailable(catch2)
+  add_subdirectory(src/tests)
+endif()
+
+file(GLOB_RECURSE ALL_CXX_SOURCE_FILES CONFIGURE_DEPENDS src/tests/*.cpp src/tests/*.h)
+file(GLOB_RECURSE ALL_CXX_SOURCE_CPP CONFIGURE_DEPENDS src/tests/*.cpp)
+add_custom_target(lint
+  COMMAND clang-format --dry-run ${ALL_CXX_SOURCE_FILES}
+  COMMAND clang-tidy ${ALL_CXX_SOURCE_CPP} -p ${CMAKE_BINARY_DIR}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,20 @@
 # lizard-hook
 Lizard Meme Keyboard Hook
+
+## Testing
+
+Build and run the test suite:
+
+```sh
+cmake -S . -B build
+cmake --build build
+cmake --build build --target test
+```
+
+Third-party dependencies are cloned at configure time; an Internet connection is required for the first build.
+
+Static analysis and formatting checks can be run with:
+
+```sh
+cmake --build build --target lint
+```

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,5 +1,4 @@
-add_library(lizard_app STATIC
-    config.cpp
-)
+add_library(lizard_app STATIC config.cpp)
 
 target_include_directories(lizard_app PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(lizard_app PUBLIC nlohmann_json::nlohmann_json)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(config_tests config_tests.cpp)
+target_link_libraries(config_tests PRIVATE lizard_app Catch2::Catch2WithMain)
+target_include_directories(config_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+add_test(NAME config COMMAND config_tests)

--- a/src/tests/config_tests.cpp
+++ b/src/tests/config_tests.cpp
@@ -1,0 +1,33 @@
+#include "app/config.h"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <fstream>
+
+using lizard::app::Config;
+
+TEST_CASE("loads default when file missing", "[config]") {
+  auto tempdir = std::filesystem::temp_directory_path() / "lizard_cfg_missing";
+  std::filesystem::create_directories(tempdir);
+  {
+    Config cfg(tempdir);
+    REQUIRE(cfg.enabled());
+    REQUIRE_FALSE(cfg.mute());
+  }
+  std::filesystem::remove_all(tempdir);
+}
+
+TEST_CASE("parses provided values", "[config]") {
+  auto tempdir = std::filesystem::temp_directory_path();
+  auto cfg_file = tempdir / "lizard_cfg.json";
+  std::ofstream out(cfg_file);
+  out << R"({"enabled":false,"emoji":["A","B"],"emoji_weighted":{"X":1.0}})";
+  out.close();
+
+  Config cfg(tempdir, cfg_file);
+  REQUIRE_FALSE(cfg.enabled());
+  REQUIRE(cfg.emoji().empty());
+  REQUIRE(cfg.emoji_weighted().at("X") == Catch::Approx(1.0));
+
+  std::filesystem::remove(cfg_file);
+}


### PR DESCRIPTION
## Summary
- fetch Catch2 and nlohmann/json at configure time instead of vendoring
- hook up config tests to Catch2WithMain and link app against nlohmann_json
- document that dependencies are cloned during the first build

## Testing
- `cmake --build build --target test`
- `cmake --build build --target lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9d23c0dc8325820e9ca88a069797