### PR TITLE
ci: install GTK dev package on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build xorg-dev libxi-dev libxrandr-dev libxinerama-dev libxcursor-dev libx11-dev libxext-dev libasound2-dev
+          sudo apt-get install -y ninja-build xorg-dev libxi-dev libxrandr-dev libxinerama-dev libxcursor-dev libx11-dev libxext-dev libasound2-dev libgtk-3-dev
 
       - name: Setup prerequisites (macOS)
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
## Summary
- install libgtk-3-dev on Ubuntu CI runners so pkg-config can locate gtk+-3.0

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_689bb3cc3ba483259a7557d1cc8968a7