### PR TITLE
Add clang-format and clang-tidy configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,8 @@
 BasedOnStyle: LLVM
 IndentWidth: 2
 ColumnLimit: 100
+SortIncludes: false
+PointerAlignment: Right
+ReferenceAlignment: Right
+UseTab: Never
+Standard: c++20

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,5 @@
-Checks: '-*,bugprone-*,modernize-*,readability-*'
+Checks: >
+  bugprone-*,performance-*,readability-*,modernize-*,clang-analyzer-*
+WarningsAsErrors: ''
 HeaderFilterRegex: 'src/.*'
-FormatStyle: none
+FormatStyle: file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,18 @@ if(BUILD_TESTING)
   add_subdirectory(src/tests)
 endif()
 
-file(GLOB_RECURSE ALL_CXX_SOURCE_FILES CONFIGURE_DEPENDS src/tests/*.cpp src/tests/*.h)
-file(GLOB_RECURSE ALL_CXX_SOURCE_CPP CONFIGURE_DEPENDS src/tests/*.cpp)
+file(GLOB_RECURSE ALL_CXX_SOURCE_FILES CONFIGURE_DEPENDS
+  src/*.cpp
+  src/*.hpp
+  src/*.h
+)
+file(GLOB_RECURSE ALL_CXX_SOURCE_CPP CONFIGURE_DEPENDS src/*.cpp)
+
+add_custom_target(format
+  COMMAND clang-format -i ${ALL_CXX_SOURCE_FILES}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 add_custom_target(lint
-  COMMAND clang-format --dry-run ${ALL_CXX_SOURCE_FILES}
+  COMMAND clang-format --dry-run --Werror ${ALL_CXX_SOURCE_FILES}
   COMMAND clang-tidy ${ALL_CXX_SOURCE_CPP} -p ${CMAKE_BINARY_DIR}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,13 @@ cmake --build build --target test
 
 Third-party dependencies are cloned at configure time; an Internet connection is required for the first build.
 
-Static analysis and formatting checks can be run with:
+Format the source tree with:
+
+```sh
+cmake --build build --target format
+```
+
+Run static analysis and formatting checks with:
 
 ```sh
 cmake --build build --target lint


### PR DESCRIPTION
## Summary
- add clang-format and clang-tidy configs for consistent C++20 style
- add `format` and `lint` CMake targets to run clang-format and clang-tidy
- document formatting and linting commands in the README

## Testing
- `cmake --build build --target format`
- `cmake --build build --target lint` *(fails: Error while processing /workspace/lizard-hook/src/hook/windows/keyboard_hook.cpp)*


------
https://chatgpt.com/codex/tasks/task_e_689bc4f7418c8325a4710f1f1ce286a2