### PR TITLE
docs: document build and usage details

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,41 @@
 # lizard-hook
 Lizard Meme Keyboard Hook
 
+## Prerequisites
+
+- [CMake](https://cmake.org/) **3.24** or newer
+- [Ninja](https://ninja-build.org/)
+- A working OpenGL 3.3 driver
+- Platform toolchains:
+  - **Windows:** [MinGW-w64](https://mingw-w64.org/) GCC 12+
+  - **macOS:** Apple Clang 14+ (via Xcode command line tools)
+  - **Linux:** GCC 12+ or Clang 15+
+
+## Building
+
+The project uses CMake presets for each platform. Configure and build with:
+
+### Windows (MinGW-w64)
+
+```sh
+cmake --preset win-mingw
+cmake --build build/win-mingw
+```
+
+### macOS
+
+```sh
+cmake --preset macos
+cmake --build build/macos
+```
+
+### Linux
+
+```sh
+cmake --preset linux
+cmake --build build/linux
+```
+
 ## Testing
 
 Build and run the test suite:
@@ -25,6 +60,19 @@ Run static analysis and formatting checks with:
 cmake --build build --target lint
 ```
 
+## Usage
+
+Run the built binary to start the keyboard overlay:
+
+- **Windows:** `build\\win-mingw\\lizard-hook.exe`
+- **macOS:** `./build/macos/lizard-hook`
+- **Linux:** `./build/linux/lizard-hook`
+
+Provide a custom configuration file with `--config path/to/lizard.json`. Without
+this option, the paths described below are searched. The overlay reacts to
+global key presses by playing a short FLAC sample and spawning fading emoji
+badges without stealing focus.
+
 ## Assets
 
 Default sound and emoji image assets are stored in the `assets/` directory and
@@ -41,6 +89,16 @@ are provided, external assets will be loaded instead of the embedded ones.
 All available configuration options are documented in `lizard.json.sample`.
 Copy this file to `lizard.json` and edit as needed.
 
+Common options include:
+
+- `enabled` and `mute` to toggle overlay and audio
+- `sound_cooldown_ms` and `max_concurrent_playbacks` to manage audio bursts
+- `badges_per_second_max`, `badge_min_px`, `badge_max_px` to tune visuals
+- `fullscreen_pause` to suspend in full-screen apps
+- `exclude_processes` to ignore specific executables
+- `sound_path` and `emoji_path` for external assets
+- `logging_level` to control verbosity
+
 Configuration values are loaded from the first location that exists:
 
 1. A path supplied via the `--config` command-line option.
@@ -51,3 +109,30 @@ Configuration values are loaded from the first location that exists:
 3. `lizard.json` located next to the executable.
 
 The application watches the selected file and reloads it automatically when it changes.
+
+## Limitations
+
+- Global keyboard hooks are unavailable on Wayland. On Wayland systems the
+  application can only operate in per-window mode.
+- Requires a functional OpenGL driver; headless environments are unsupported.
+
+## Contributing
+
+Contributions are welcome! Please:
+
+1. Fork the repository and create a topic branch.
+2. Ensure the project builds and tests pass:
+
+   ```sh
+   cmake -S . -B build
+   cmake --build build
+   cmake --build build --target test
+   cmake --build build --target lint
+   ```
+
+3. Use `cmake --build build --target format` to apply formatting.
+4. Open a pull request describing your changes.
+
+## License
+
+This project is released under the [MIT License](license.md).


### PR DESCRIPTION
## Summary
- document prerequisites and platform-specific build steps using CMake presets
- add runtime usage, configuration highlights, known limitations, and contribution guidelines

## Testing
- `cmake -S . -B build` *(fails: Package 'gtk+-3.0' not found)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `cmake --build build --target test` *(fails: No rule to make target 'Makefile')*
- `cmake --build build --target lint` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_689bcfd057648325ae33aba981e1252f