### PR TITLE
Add volume control to audio engine

### DIFF
--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -128,4 +128,6 @@ const std::optional<std::filesystem::path> &Config::sound_path() const { return 
 
 const std::optional<std::filesystem::path> &Config::emoji_path() const { return emoji_path_; }
 
+int Config::volume_percent() const { return volume_percent_; }
+
 } // namespace lizard::app

--- a/src/app/config.h
+++ b/src/app/config.h
@@ -21,6 +21,7 @@ public:
   const std::unordered_map<std::string, double> &emoji_weighted() const;
   const std::optional<std::filesystem::path> &sound_path() const;
   const std::optional<std::filesystem::path> &emoji_path() const;
+  int volume_percent() const;
 
 private:
   void load();

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -72,7 +72,8 @@ public:
 
   ~Engine() { shutdown(); }
 
-  bool init(std::optional<std::filesystem::path> sound_path = std::nullopt) {
+  bool init(std::optional<std::filesystem::path> sound_path = std::nullopt,
+            int config_volume_percent = 100) {
     ma_result result = ma_engine_init(nullptr, &m_engine);
     if (result != MA_SUCCESS) {
       return false;
@@ -102,6 +103,7 @@ public:
     for (auto &voice : m_voices) {
       ma_sound_init_from_data_source(&m_engine, &m_buffer, 0, nullptr, &voice.sound);
     }
+    set_volume(static_cast<float>(config_volume_percent) / 100.0f);
     return true;
   }
 
@@ -140,6 +142,13 @@ public:
     target->start = now;
   }
 
+  void set_volume(float vol) {
+    m_volume = std::clamp(vol, 0.0f, 1.0f);
+    for (auto &voice : m_voices) {
+      ma_sound_set_volume(&voice.sound, m_volume);
+    }
+  }
+
 private:
   struct Voice {
     ma_sound sound{};
@@ -153,6 +162,7 @@ private:
   std::uint32_t m_maxPlaybacks = 0;
   std::chrono::steady_clock::time_point m_lastPlay{};
   std::chrono::milliseconds m_cooldown{};
+  float m_volume{1.0f};
 };
 
 } // namespace lizard::audio


### PR DESCRIPTION
## Summary
- Add volume member and setter to audio engine and apply to all voices
- Initialize audio volume from Config's percentage
- Expose volume_percent in Config for runtime adjustments

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`
- `clang-format --dry-run --Werror src/audio/engine.cpp src/app/config.h src/app/config.cpp`
- `cmake --build build --target lint` *(fails: code should be clang-formatted in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689bd65d10648325ac8f98ca770e1374