### PR TITLE
Expose additional configuration getters

### DIFF
--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -135,8 +135,30 @@ const std::optional<std::filesystem::path> &Config::sound_path() const { return 
 
 const std::optional<std::filesystem::path> &Config::emoji_path() const { return emoji_path_; }
 
-const std::string &Config::logging_level() const { return logging_level_; }
+int Config::sound_cooldown_ms() const { return sound_cooldown_ms_; }
+
+int Config::max_concurrent_playbacks() const { return max_concurrent_playbacks_; }
+
+int Config::badges_per_second_max() const { return badges_per_second_max_; }
+
+int Config::badge_min_px() const { return badge_min_px_; }
+
+int Config::badge_max_px() const { return badge_max_px_; }
+
+bool Config::fullscreen_pause() const { return fullscreen_pause_; }
+
+const std::vector<std::string> &Config::exclude_processes() const { return exclude_processes_; }
+
+bool Config::ignore_injected() const { return ignore_injected_; }
+
+const std::string &Config::audio_backend() const { return audio_backend_; }
+
+const std::string &Config::badge_spawn_strategy() const { return badge_spawn_strategy_; }
 
 int Config::volume_percent() const { return volume_percent_; }
+
+const std::string &Config::dpi_scaling_mode() const { return dpi_scaling_mode_; }
+
+const std::string &Config::logging_level() const { return logging_level_; }
 
 } // namespace lizard::app

--- a/src/app/config.h
+++ b/src/app/config.h
@@ -21,8 +21,19 @@ public:
   const std::unordered_map<std::string, double> &emoji_weighted() const;
   const std::optional<std::filesystem::path> &sound_path() const;
   const std::optional<std::filesystem::path> &emoji_path() const;
-  const std::string &logging_level() const;
+  int sound_cooldown_ms() const;
+  int max_concurrent_playbacks() const;
+  int badges_per_second_max() const;
+  int badge_min_px() const;
+  int badge_max_px() const;
+  bool fullscreen_pause() const;
+  const std::vector<std::string> &exclude_processes() const;
+  bool ignore_injected() const;
+  const std::string &audio_backend() const;
+  const std::string &badge_spawn_strategy() const;
   int volume_percent() const;
+  const std::string &dpi_scaling_mode() const;
+  const std::string &logging_level() const;
 
 private:
   void load();


### PR DESCRIPTION
## Summary
- add accessors for various configuration fields such as sound cooldown, audio backend, and DPI scaling mode
- expose configuration options like badge spawn strategy and exclude processes

## Testing
- `clang-format --dry-run -Werror src/app/config.h src/app/config.cpp`
- `cmake --build build/linux` *(failed: array-bounds errors in spdlog)*
- `clang-tidy src/app/config.cpp -p build/linux` *(failed: unknown key 'AnalyzeTemporaryDtors')*

------
https://chatgpt.com/codex/tasks/task_e_689bdc15d4cc8325a59f50474e8ee41b