### PR TITLE
Ensure OpenGL resources released on window teardown

### DIFF
--- a/src/platform/linux/window.cpp
+++ b/src/platform/linux/window.cpp
@@ -18,8 +18,7 @@ float compute_dpi(Display *dpy, ::Window win) {
   int screen = DefaultScreen(dpy);
   int width_px = DisplayWidth(dpy, screen);
   int width_mm = DisplayWidthMM(dpy, screen);
-  float dpi =
-      static_cast<float>(width_px) / static_cast<float>(width_mm) * 25.4f;
+  float dpi = static_cast<float>(width_px) / static_cast<float>(width_mm) * 25.4f;
   return dpi / 96.0f;
 }
 
@@ -39,10 +38,9 @@ Window create_overlay_window(const WindowDesc &desc) {
   attrs.event_mask = StructureNotifyMask;
   attrs.background_pixel = 0;
 
-  ::Window win =
-      XCreateWindow(g_display, g_root, 0, 0, desc.width, desc.height, 0,
-                    CopyFromParent, InputOutput, CopyFromParent,
-                    CWOverrideRedirect | CWEventMask | CWBackPixel, &attrs);
+  ::Window win = XCreateWindow(g_display, g_root, 0, 0, desc.width, desc.height, 0, CopyFromParent,
+                               InputOutput, CopyFromParent,
+                               CWOverrideRedirect | CWEventMask | CWBackPixel, &attrs);
 
   XMapRaised(g_display, win);
 
@@ -73,10 +71,9 @@ Window create_overlay_window(const WindowDesc &desc) {
     fb = configs[0];
     XFree(configs);
   }
-  using CreateContext =
-      GLXContext (*)(Display *, GLXFBConfig, GLXContext, Bool, const int *);
-  auto createContext = (CreateContext)glXGetProcAddress(
-      (const GLubyte *)"glXCreateContextAttribsARB");
+  using CreateContext = GLXContext (*)(Display *, GLXFBConfig, GLXContext, Bool, const int *);
+  auto createContext =
+      (CreateContext)glXGetProcAddress((const GLubyte *)"glXCreateContextAttribsARB");
   int ctxAttr[] = {GLX_CONTEXT_MAJOR_VERSION_ARB,
                    3,
                    GLX_CONTEXT_MINOR_VERSION_ARB,
@@ -93,14 +90,20 @@ Window create_overlay_window(const WindowDesc &desc) {
 
   result.native = (void *)win;
   result.dpiScale = compute_dpi(g_display, win);
+  result.glContext = ctx;
   return result;
 }
 
 void destroy_window(Window &window) {
   if (g_display && window.native) {
     glXMakeCurrent(g_display, None, nullptr);
+    if (window.glContext) {
+      glXDestroyContext(g_display, window.glContext);
+      window.glContext = nullptr;
+    }
     XDestroyWindow(g_display, (::Window)window.native);
     XCloseDisplay(g_display);
+    g_display = nullptr;
   }
   window.native = nullptr;
 }

--- a/src/platform/win/window.cpp
+++ b/src/platform/win/window.cpp
@@ -30,11 +30,10 @@ Window create_overlay_window(const WindowDesc &desc) {
   wc.lpszClassName = L"LizardOverlay";
   RegisterClassW(&wc);
 
-  DWORD exStyle = WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST |
-                  WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
-  g_hwnd =
-      CreateWindowExW(exStyle, wc.lpszClassName, L"", WS_POPUP, 0, 0,
-                      desc.width, desc.height, nullptr, nullptr, inst, nullptr);
+  DWORD exStyle =
+      WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+  g_hwnd = CreateWindowExW(exStyle, wc.lpszClassName, L"", WS_POPUP, 0, 0, desc.width, desc.height,
+                           nullptr, nullptr, inst, nullptr);
   if (!g_hwnd) {
     return result;
   }
@@ -57,11 +56,22 @@ Window create_overlay_window(const WindowDesc &desc) {
 
   result.native = g_hwnd;
   result.dpiScale = compute_dpi(g_hwnd);
+  result.glContext = rc;
+  result.device = dc;
   return result;
 }
 
 void destroy_window(Window &window) {
   if (window.native) {
+    wglMakeCurrent(nullptr, nullptr);
+    if (window.glContext) {
+      wglDeleteContext(window.glContext);
+      window.glContext = nullptr;
+    }
+    if (window.device) {
+      ReleaseDC((HWND)window.native, window.device);
+      window.device = nullptr;
+    }
     DestroyWindow((HWND)window.native);
   }
   window.native = nullptr;

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#ifdef _WIN32
+#include <windows.h>
+#elif defined(__linux__)
+#include <GL/glx.h>
+#endif
 
 namespace lizard::platform {
 
@@ -12,6 +17,12 @@ struct WindowDesc {
 struct Window {
   void *native = nullptr;
   float dpiScale = 1.0f;
+#ifdef _WIN32
+  HGLRC glContext = nullptr;
+  HDC device = nullptr;
+#elif defined(__linux__)
+  GLXContext glContext = nullptr;
+#endif
 };
 
 Window create_overlay_window(const WindowDesc &desc);


### PR DESCRIPTION
## Summary
- track OpenGL context and device handles in Window
- properly unbind and destroy GL context/close display on Windows and Linux

## Testing
- `clang-format --dry-run src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp`
- `clang-tidy src/platform/win/window.cpp` *(fails: Could not auto-detect compilation database)*
- `clang-tidy src/platform/linux/window.cpp` *(fails: Could not auto-detect compilation database)*
- `cmake -S . -B build` *(interrupted: partial configuration log)*

------
https://chatgpt.com/codex/tasks/task_e_689be26e4a1883258c5b179204599549