### PR TITLE
Add audio engine header and configurable backend

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -15,8 +15,11 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(miniaudio drflac)
 
 add_library(lizard_audio STATIC engine.cpp)
+target_sources(lizard_audio PUBLIC engine.h)
 
 target_include_directories(lizard_audio
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE
     ${miniaudio_SOURCE_DIR}
     ${drflac_SOURCE_DIR}

--- a/src/audio/engine.h
+++ b/src/audio/engine.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+struct ma_engine;
+struct ma_context;
+struct ma_audio_buffer_config;
+struct ma_audio_buffer;
+struct ma_sound;
+
+namespace lizard::audio {
+
+class Engine {
+public:
+  Engine(std::uint32_t maxPlaybacks, std::chrono::milliseconds cooldown);
+  ~Engine();
+
+  bool init(std::optional<std::filesystem::path> sound_path = std::nullopt,
+            int volume_percent = 100, std::string_view backend = "miniaudio");
+  void shutdown();
+  void play();
+  void set_volume(float vol);
+
+private:
+  struct Voice {
+    ma_sound sound{};
+    std::chrono::steady_clock::time_point start{};
+  };
+
+  ma_engine m_engine{};
+  ma_context m_context{};
+  bool m_contextInitialized{false};
+  ma_audio_buffer_config m_bufferConfig{};
+  ma_audio_buffer m_buffer{};
+  std::vector<Voice> m_voices;
+  std::uint32_t m_maxPlaybacks = 0;
+  std::chrono::steady_clock::time_point m_lastPlay{};
+  std::chrono::milliseconds m_cooldown{};
+  float m_volume{1.0f};
+};
+
+} // namespace lizard::audio


### PR DESCRIPTION
## Summary
- Add `Engine` class declaration to new `engine.h`
- Support backend selection in audio engine initialization and clamp volume percent
- Expose header via CMake for consumers

## Testing
- ✅ `clang-format --dry-run src/audio/engine.h src/audio/engine.cpp`
- ✅ `cmake --preset linux`
- ⚠️ `cmake --build build/linux` *(fails: GL_TIMEOUT_IGNORED redefined)*
- ⚠️ `clang-tidy src/audio/engine.cpp -p build/linux` *(fails: unknown key 'AnalyzeTemporaryDtors')*

------
https://chatgpt.com/codex/tasks/task_e_689ca68382d88325a5bf90e025dd580e