### PR TITLE
Derive custom atlas JSON path

### DIFF
--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -32,7 +32,9 @@
   // Path to external sound file; empty string uses embedded asset
   "sound_path": "",
 
-  // Path to external emoji atlas image; empty string uses embedded asset
+  // Path to external emoji atlas image; matching `<emoji_path>.json` or an
+  // `emoji_atlas.json` in the same directory provides sprite coordinates. Empty
+  // string uses embedded assets.
   "emoji_path": "",
 
   // Audio backend selection (default: "miniaudio")

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,10 @@ into binary arrays that are linked into the final binary.
 
 To override these defaults at runtime, set `sound_path` and `emoji_path` in the
 `lizard.json` configuration file to point to external files. When these paths
-are provided, external assets will be loaded instead of the embedded ones.
+are provided, external assets will be loaded instead of the embedded ones. For
+`emoji_path`, the overlay looks for sprite coordinates in `<emoji_path>.json` or
+an `emoji_atlas.json` file in the same directory. If neither is found, the
+embedded atlas is used.
 
 ## Configuration
 

--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <optional>
 #include <random>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -107,25 +108,53 @@ bool Overlay::init(const app::Config &cfg, std::optional<std::filesystem::path> 
   stbi_image_free(pixels);
 
   // Load sprite UVs from atlas
-  std::ifstream atlas_in(std::filesystem::path("assets") / "emoji_atlas.json");
-  if (atlas_in.is_open()) {
-    try {
-      json j;
-      atlas_in >> j;
-      if (j.contains("sprites") && j["sprites"].is_object()) {
-        for (const auto &[emoji, s] : j["sprites"].items()) {
-          Sprite sp{};
-          sp.u0 = s.value("u0", 0.0f);
-          sp.v0 = s.value("v0", 0.0f);
-          sp.u1 = s.value("u1", 1.0f);
-          sp.v1 = s.value("v1", 1.0f);
-          m_sprite_lookup[emoji] = static_cast<int>(m_sprites.size());
-          m_sprites.push_back(sp);
+  std::ifstream atlas_file;
+  std::istringstream atlas_default(R"({
+  "sprites": {
+    "🦎": { "u0": 0.0, "v0": 0.0, "u1": 0.5, "v1": 0.5 },
+    "🐍": { "u0": 0.5, "v0": 0.0, "u1": 1.0, "v1": 0.5 },
+    "🐢": { "u0": 0.0, "v0": 0.5, "u1": 0.5, "v1": 1.0 }
+  }
+})");
+  std::istream *atlas = nullptr;
+  if (emoji_path) {
+    std::filesystem::path json_path = *emoji_path;
+    json_path += ".json";
+    if (std::filesystem::exists(json_path)) {
+      atlas_file.open(json_path);
+      if (atlas_file.is_open()) {
+        atlas = &atlas_file;
+      }
+    }
+    if (!atlas) {
+      json_path = emoji_path->parent_path() / "emoji_atlas.json";
+      if (std::filesystem::exists(json_path)) {
+        atlas_file.open(json_path);
+        if (atlas_file.is_open()) {
+          atlas = &atlas_file;
         }
       }
-    } catch (const std::exception &) {
-      // fall back to default below
     }
+  }
+  if (!atlas) {
+    atlas = &atlas_default;
+  }
+  try {
+    json j;
+    *atlas >> j;
+    if (j.contains("sprites") && j["sprites"].is_object()) {
+      for (const auto &[emoji, s] : j["sprites"].items()) {
+        Sprite sp{};
+        sp.u0 = s.value("u0", 0.0f);
+        sp.v0 = s.value("v0", 0.0f);
+        sp.u1 = s.value("u1", 1.0f);
+        sp.v1 = s.value("v1", 1.0f);
+        m_sprite_lookup[emoji] = static_cast<int>(m_sprites.size());
+        m_sprites.push_back(sp);
+      }
+    }
+  } catch (const std::exception &) {
+    // fall back to single sprite below
   }
   if (m_sprites.empty()) {
     m_sprites.push_back({0.0f, 0.0f, 1.0f, 1.0f});


### PR DESCRIPTION
## Summary
- Load sprite atlas JSON next to `emoji_path` (either `<emoji_path>.json` or `emoji_atlas.json` in the same directory), with embedded atlas fallback
- Document external atlas lookup behavior in README and sample config

## Testing
- `clang-format --dry-run --Werror src/overlay/overlay.cpp`
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: ma_sound has incomplete type)*


------
https://chatgpt.com/codex/tasks/task_e_689cabb3417c83259a52a73e6936bc0f