### PR TITLE
Use system metrics for Win32 overlay window

### DIFF
--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -72,7 +72,11 @@ private:
 };
 
 bool Overlay::init(const app::Config &cfg, std::optional<std::filesystem::path> emoji_path) {
+#ifdef _WIN32
+  platform::WindowDesc desc{0, 0};
+#else
   platform::WindowDesc desc{800, 600};
+#endif
   m_window = platform::create_overlay_window(desc);
   if (!m_window.native) {
     return false;

--- a/src/platform/win/window.cpp
+++ b/src/platform/win/window.cpp
@@ -21,7 +21,7 @@ LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 }
 } // namespace
 
-Window create_overlay_window(const WindowDesc &desc) {
+Window create_overlay_window([[maybe_unused]] const WindowDesc &desc) {
   Window result{};
   HINSTANCE inst = GetModuleHandle(nullptr);
   WNDCLASSW wc{};
@@ -32,8 +32,12 @@ Window create_overlay_window(const WindowDesc &desc) {
 
   DWORD exStyle =
       WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
-  g_hwnd = CreateWindowExW(exStyle, wc.lpszClassName, L"", WS_POPUP, 0, 0, desc.width, desc.height,
-                           nullptr, nullptr, inst, nullptr);
+  int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+  int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+  int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+  int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+  g_hwnd = CreateWindowExW(exStyle, wc.lpszClassName, L"", WS_POPUP, x, y, width, height, nullptr,
+                           nullptr, inst, nullptr);
   if (!g_hwnd) {
     return result;
   }
@@ -56,6 +60,8 @@ Window create_overlay_window(const WindowDesc &desc) {
 
   result.native = g_hwnd;
   result.dpiScale = compute_dpi(g_hwnd);
+  SetWindowPos(g_hwnd, nullptr, x, y, static_cast<int>(width * result.dpiScale),
+               static_cast<int>(height * result.dpiScale), SWP_NOZORDER | SWP_NOACTIVATE);
   result.glContext = rc;
   result.device = dc;
   return result;

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -12,6 +12,7 @@ namespace lizard::platform {
 struct WindowDesc {
   std::uint32_t width;
   std::uint32_t height;
+  // On Windows the overlay always spans the virtual screen, so these are ignored.
 };
 
 struct Window {


### PR DESCRIPTION
## Summary
- size Win32 overlay window using virtual screen metrics and resize for DPI
- ignore WindowDesc width/height on Windows; ensure overlay spans entire desktop
- make WindowDesc conditional usage in overlay creation

## Testing
- `clang-format --dry-run src/platform/win/window.cpp src/overlay/overlay.cpp src/platform/window.hpp`
- `cmake --preset linux` *(pass)*
- `cmake --build build/linux` *(fails: deprecated GTK status icon warnings treated as errors)*
- `clang-tidy src/platform/win/window.cpp src/overlay/overlay.cpp src/platform/window.hpp -p build/linux` *(fails: errors in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689cabaec80483259d94864cb57f5576