### PR TITLE
Protect config with shared mutex

### DIFF
--- a/src/app/config.h
+++ b/src/app/config.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -17,28 +18,29 @@ public:
 
   bool enabled() const;
   bool mute() const;
-  const std::vector<std::string> &emoji() const;
-  const std::unordered_map<std::string, double> &emoji_weighted() const;
-  const std::optional<std::filesystem::path> &sound_path() const;
-  const std::optional<std::filesystem::path> &emoji_path() const;
+  std::vector<std::string> emoji() const;
+  std::unordered_map<std::string, double> emoji_weighted() const;
+  std::optional<std::filesystem::path> sound_path() const;
+  std::optional<std::filesystem::path> emoji_path() const;
   int sound_cooldown_ms() const;
   int max_concurrent_playbacks() const;
   int badges_per_second_max() const;
   int badge_min_px() const;
   int badge_max_px() const;
   bool fullscreen_pause() const;
-  const std::vector<std::string> &exclude_processes() const;
+  std::vector<std::string> exclude_processes() const;
   bool ignore_injected() const;
-  const std::string &audio_backend() const;
-  const std::string &badge_spawn_strategy() const;
+  std::string audio_backend() const;
+  std::string badge_spawn_strategy() const;
   int volume_percent() const;
-  const std::string &dpi_scaling_mode() const;
-  const std::string &logging_level() const;
+  std::string dpi_scaling_mode() const;
+  std::string logging_level() const;
 
 private:
-  void load();
+  void load(std::unique_lock<std::shared_mutex> &lock);
   static std::filesystem::path user_config_path();
 
+  mutable std::shared_mutex mutex_;
   std::filesystem::path config_path_;
   std::filesystem::file_time_type last_write_{};
   std::jthread watcher_;


### PR DESCRIPTION
## Summary
- add a shared_mutex to Config and guard writes with unique_lock
- guard Config accessors with shared_lock and return copies
- ensure watcher thread locks config before reloading

## Testing
- `cmake -S . -B build` *(fails: gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf26f922c83258c16807725f70401