### PR TITLE
Handle optional asset paths in config

### DIFF
--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -29,12 +29,13 @@
   // Ignore injected or synthetic key events (default: true)
   "ignore_injected": true,
 
-  // Path to external sound file; empty string uses embedded asset
+  // Path to external sound file; omit or set to an empty string to use the
+  // embedded asset
   "sound_path": "",
 
   // Path to external emoji atlas image; matching `<emoji_path>.json` or an
-  // `emoji_atlas.json` in the same directory provides sprite coordinates. Empty
-  // string uses embedded assets.
+  // `emoji_atlas.json` in the same directory provides sprite coordinates. Omit
+  // or set to an empty string to use embedded assets.
   "emoji_path": "",
 
   // Audio backend selection (default: "miniaudio")

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -127,10 +127,25 @@ void Config::load(std::unique_lock<std::shared_mutex> &lock) {
     logging_level_ = j.value("logging_level", std::string("info"));
 
     if (j.contains("sound_path")) {
-      sound_path_ = j.at("sound_path").get<std::string>();
+      auto path = j.at("sound_path").get<std::string>();
+      if (path.empty()) {
+        sound_path_ = std::nullopt;
+      } else {
+        sound_path_ = path;
+      }
+    } else {
+      sound_path_ = std::nullopt;
     }
+
     if (j.contains("emoji_path")) {
-      emoji_path_ = j.at("emoji_path").get<std::string>();
+      auto path = j.at("emoji_path").get<std::string>();
+      if (path.empty()) {
+        emoji_path_ = std::nullopt;
+      } else {
+        emoji_path_ = path;
+      }
+    } else {
+      emoji_path_ = std::nullopt;
     }
 
     if (j.contains("emoji_weighted")) {

--- a/src/tests/config_tests.cpp
+++ b/src/tests/config_tests.cpp
@@ -49,6 +49,43 @@ TEST_CASE("parses asset paths", "[config]") {
   std::filesystem::remove(cfg_file);
 }
 
+TEST_CASE("asset paths reset when removed or empty", "[config]") {
+  using namespace std::chrono_literals;
+  auto tempdir = std::filesystem::temp_directory_path();
+  auto cfg_file = tempdir / "lizard_cfg_paths_reset.json";
+
+  {
+    std::ofstream out(cfg_file);
+    out << R"({"sound_path":"custom.flac","emoji_path":"custom.png"})";
+  }
+
+  Config cfg(tempdir, cfg_file);
+  REQUIRE(cfg.sound_path().has_value());
+  REQUIRE(cfg.emoji_path().has_value());
+
+  std::this_thread::sleep_for(1s);
+  {
+    std::ofstream out(cfg_file);
+    out << R"({"sound_path":"","emoji_path":""})";
+  }
+
+  std::this_thread::sleep_for(2s);
+  REQUIRE_FALSE(cfg.sound_path().has_value());
+  REQUIRE_FALSE(cfg.emoji_path().has_value());
+
+  std::this_thread::sleep_for(1s);
+  {
+    std::ofstream out(cfg_file);
+    out << R"({})";
+  }
+
+  std::this_thread::sleep_for(2s);
+  REQUIRE_FALSE(cfg.sound_path().has_value());
+  REQUIRE_FALSE(cfg.emoji_path().has_value());
+
+  std::filesystem::remove(cfg_file);
+}
+
 TEST_CASE("reloads on file change", "[config]") {
   using namespace std::chrono_literals;
   auto tempdir = std::filesystem::temp_directory_path();


### PR DESCRIPTION
## Summary
- Treat missing or empty `sound_path` and `emoji_path` entries as defaults in `Config::load`
- Document optional `sound_path`/`emoji_path` behavior in sample config
- Test that removing or blanking asset path keys restores defaults

## Testing
- `cmake --preset linux` *(pass)*
- `cmake --build build/linux` *(fail: spdlog deprecated declaration error)*

------
https://chatgpt.com/codex/tasks/task_e_689d112def1c8325ace21f8bded3ef48