### PR TITLE
Query monitor dimensions for overlay

### DIFF
--- a/src/platform/linux/window.cpp
+++ b/src/platform/linux/window.cpp
@@ -38,8 +38,8 @@ Window create_overlay_window(const WindowDesc &desc) {
   attrs.event_mask = StructureNotifyMask;
   attrs.background_pixel = 0;
 
-  ::Window win = XCreateWindow(g_display, g_root, 0, 0, desc.width, desc.height, 0, CopyFromParent,
-                               InputOutput, CopyFromParent,
+  ::Window win = XCreateWindow(g_display, g_root, desc.x, desc.y, desc.width, desc.height, 0,
+                               CopyFromParent, InputOutput, CopyFromParent,
                                CWOverrideRedirect | CWEventMask | CWBackPixel, &attrs);
 
   XMapRaised(g_display, win);

--- a/src/platform/mac/window.mm
+++ b/src/platform/mac/window.mm
@@ -19,10 +19,11 @@ Window create_overlay_window(const WindowDesc &desc) {
   Window result{};
   @autoreleasepool {
     NSUInteger style = NSWindowStyleMaskBorderless;
-    g_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, desc.width, desc.height)
-                                           styleMask:style
-                                             backing:NSBackingStoreBuffered
-                                               defer:NO];
+    g_window =
+        [[NSWindow alloc] initWithContentRect:NSMakeRect(desc.x, desc.y, desc.width, desc.height)
+                                    styleMask:style
+                                      backing:NSBackingStoreBuffered
+                                        defer:NO];
     [g_window setLevel:NSStatusWindowLevel];
     [g_window setOpaque:NO];
     [g_window setIgnoresMouseEvents:YES];

--- a/src/platform/win/window.cpp
+++ b/src/platform/win/window.cpp
@@ -21,7 +21,7 @@ LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 }
 } // namespace
 
-Window create_overlay_window([[maybe_unused]] const WindowDesc &desc) {
+Window create_overlay_window(const WindowDesc &desc) {
   Window result{};
   HINSTANCE inst = GetModuleHandle(nullptr);
   WNDCLASSW wc{};
@@ -32,10 +32,16 @@ Window create_overlay_window([[maybe_unused]] const WindowDesc &desc) {
 
   DWORD exStyle =
       WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
-  int x = GetSystemMetrics(SM_XVIRTUALSCREEN);
-  int y = GetSystemMetrics(SM_YVIRTUALSCREEN);
-  int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-  int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+  int x = desc.x;
+  int y = desc.y;
+  int width = static_cast<int>(desc.width);
+  int height = static_cast<int>(desc.height);
+  if (width == 0 || height == 0) {
+    x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+  }
   g_hwnd = CreateWindowExW(exStyle, wc.lpszClassName, L"", WS_POPUP, x, y, width, height, nullptr,
                            nullptr, inst, nullptr);
   if (!g_hwnd) {

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -12,6 +12,8 @@ class NSOpenGLContext;
 namespace lizard::platform {
 
 struct WindowDesc {
+  std::int32_t x;
+  std::int32_t y;
   std::uint32_t width;
   std::uint32_t height;
   // On Windows the overlay always spans the virtual screen, so these are ignored.


### PR DESCRIPTION
## Summary
- query monitor geometry per platform to size overlay window
- support window position via extended `WindowDesc`
- use platform APIs on Linux, macOS, and Windows to span all displays

## Testing
- `clang-format --dry-run -Werror src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/overlay/overlay.cpp`
- `cmake --preset linux` *(fails: gtk+ dependency initially missing, installed; build later fails due to spdlog deprecated declarations treated as errors)*
- `clang-tidy src/overlay/overlay.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm -- -I./src` *(fails: numerous warnings treated as errors)*


------
https://chatgpt.com/codex/tasks/task_e_689d112c1668832590770cace9164445