### PR TITLE
Handle XRecord range allocation failure

### DIFF
--- a/src/tests/hook_tests.cpp
+++ b/src/tests/hook_tests.cpp
@@ -1,6 +1,7 @@
 #include "hook/keyboard_hook.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -18,6 +19,12 @@ void set_cg_event_tap_create(CGEventTapCreateFn fn);
 } // namespace hook::testing
 #elif defined(__linux__)
 #include <cstdlib>
+#include <X11/Xlib.h>
+#include <X11/extensions/record.h>
+namespace hook::testing {
+using AllocRangeFn = XRecordRange *(*)();
+void set_xrecord_alloc_range(AllocRangeFn fn);
+} // namespace hook::testing
 #endif
 
 TEST_CASE("start fails when platform API unavailable", "[hook]") {
@@ -31,9 +38,40 @@ TEST_CASE("start fails when platform API unavailable", "[hook]") {
                                             CGEventTapOptions, CGEventMask, CGEventTapCallBack,
                                             void *) { return (CFMachPortRef) nullptr; });
 #elif defined(__linux__)
-  setenv("DISPLAY", "", 1);
-#endif
-
+  const char *old_display = std::getenv("DISPLAY");
+  if (old_display) {
+    std::string saved = old_display;
+    setenv("DISPLAY", "", 1);
+    auto hk = hook::KeyboardHook::create([](int, bool) {});
+    REQUIRE_FALSE(hk->start());
+    setenv("DISPLAY", saved.c_str(), 1);
+  } else {
+    setenv("DISPLAY", "", 1);
+    auto hk = hook::KeyboardHook::create([](int, bool) {});
+    REQUIRE_FALSE(hk->start());
+    unsetenv("DISPLAY");
+  }
+#else
   auto hk = hook::KeyboardHook::create([](int, bool) {});
   REQUIRE_FALSE(hk->start());
+#endif
 }
+
+#if defined(__linux__)
+TEST_CASE("start fails when XRecordAllocRange fails", "[hook]") {
+  if (Display *d = XOpenDisplay(nullptr)) {
+    XCloseDisplay(d);
+    static bool called = false;
+    auto failing_alloc = []() -> XRecordRange * {
+      called = true;
+      return nullptr;
+    };
+    hook::testing::set_xrecord_alloc_range(failing_alloc);
+    auto hk = hook::KeyboardHook::create([](int, bool) {});
+    REQUIRE_FALSE(hk->start());
+    REQUIRE(called);
+  } else {
+    SUCCEED("X display unavailable; skipping test");
+  }
+}
+#endif


### PR DESCRIPTION
## Summary
- ensure XRecord range allocation is checked and clean up resources on failure
- allow tests to override XRecordAllocRange and exercise failure path
- cover Linux XRecord allocation failure in hook unit tests

## Testing
- `./build/linux/src/tests/hook_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a25b148cfc83259df14ac3c371e094