### PR TITLE
Add macOS tray icon

### DIFF
--- a/assets/embedded.h
+++ b/assets/embedded.h
@@ -5,4 +5,4 @@ extern const unsigned char lizard_regular_png[];
 extern const unsigned int lizard_regular_png_len;
 extern const unsigned char lizard_processed_clean_no_meta_flac[];
 extern const unsigned int lizard_processed_clean_no_meta_flac_len;
-}
+} // namespace lizard::assets

--- a/readme.md
+++ b/readme.md
@@ -75,10 +75,11 @@ badges without stealing focus.
 
 ## Assets
 
-Default sound and emoji image assets are stored in the `assets/` directory and
-are embedded into the executable at build time. The build system converts
+Default sound and emoji assets are stored in the `assets/` directory and are
+embedded into the executable at build time. The build system converts
 `assets/lizard-processed-clean-no-meta.flac` and `assets/lizard-regular.png`
-into binary arrays that are linked into the final binary.
+into binary arrays that are linked into the final binary. The PNG is also used
+as the macOS tray icon.
 
 To override these defaults at runtime, set `sound_path` and `emoji_path` in the
 `lizard.json` configuration file to point to external files. When these paths

--- a/src/platform/mac/CMakeLists.txt
+++ b/src/platform/mac/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_library(lizard_platform_mac window.mm tray.mm)
 
-    target_include_directories(
-        lizard_platform_mac PUBLIC ${CMAKE_CURRENT_LIST_DIR} /..)
+target_include_directories(
+  lizard_platform_mac PUBLIC ${CMAKE_CURRENT_LIST_DIR} /..
+)
 
-        target_link_libraries(lizard_platform_mac PUBLIC "-framework Cocoa"
-                                                         "-framework OpenGL")
+target_link_libraries(
+  lizard_platform_mac PUBLIC "-framework Cocoa" "-framework OpenGL" embedded_assets
+)
+
 add_warning_flags(lizard_platform_mac)

--- a/src/platform/mac/tray.mm
+++ b/src/platform/mac/tray.mm
@@ -2,6 +2,7 @@
 
 #ifdef __APPLE__
 #import <Cocoa/Cocoa.h>
+#include "embedded.h"
 
 namespace lizard::platform {
 
@@ -23,29 +24,25 @@ NSMenuItem *g_fps = nil;
   g_state.enabled = !g_state.enabled;
   if (g_callbacks.toggle_enabled)
     g_callbacks.toggle_enabled(g_state.enabled);
-  [g_enabled setState:g_state.enabled ? NSControlStateValueOn
-                                      : NSControlStateValueOff];
+  [g_enabled setState:g_state.enabled ? NSControlStateValueOn : NSControlStateValueOff];
 }
 - (void)toggleMute:(id)sender {
   g_state.muted = !g_state.muted;
   if (g_callbacks.toggle_mute)
     g_callbacks.toggle_mute(g_state.muted);
-  [g_mute
-      setState:g_state.muted ? NSControlStateValueOn : NSControlStateValueOff];
+  [g_mute setState:g_state.muted ? NSControlStateValueOn : NSControlStateValueOff];
 }
 - (void)toggleFullscreen:(id)sender {
   g_state.fullscreen_pause = !g_state.fullscreen_pause;
   if (g_callbacks.toggle_fullscreen_pause)
     g_callbacks.toggle_fullscreen_pause(g_state.fullscreen_pause);
-  [g_fullscreen setState:g_state.fullscreen_pause ? NSControlStateValueOn
-                                                  : NSControlStateValueOff];
+  [g_fullscreen setState:g_state.fullscreen_pause ? NSControlStateValueOn : NSControlStateValueOff];
 }
 - (void)toggleFPS:(id)sender {
   g_state.show_fps = !g_state.show_fps;
   if (g_callbacks.toggle_fps)
     g_callbacks.toggle_fps(g_state.show_fps);
-  [g_fps setState:g_state.show_fps ? NSControlStateValueOn
-                                   : NSControlStateValueOff];
+  [g_fps setState:g_state.show_fps ? NSControlStateValueOn : NSControlStateValueOff];
 }
 - (void)openConfig:(id)sender {
   if (g_callbacks.open_config)
@@ -64,14 +61,10 @@ NSMenuItem *g_fps = nil;
 TrayTarget *g_target = nil;
 
 void rebuild_menu() {
-  [g_enabled setState:g_state.enabled ? NSControlStateValueOn
-                                      : NSControlStateValueOff];
-  [g_mute
-      setState:g_state.muted ? NSControlStateValueOn : NSControlStateValueOff];
-  [g_fullscreen setState:g_state.fullscreen_pause ? NSControlStateValueOn
-                                                  : NSControlStateValueOff];
-  [g_fps setState:g_state.show_fps ? NSControlStateValueOn
-                                   : NSControlStateValueOff];
+  [g_enabled setState:g_state.enabled ? NSControlStateValueOn : NSControlStateValueOff];
+  [g_mute setState:g_state.muted ? NSControlStateValueOn : NSControlStateValueOff];
+  [g_fullscreen setState:g_state.fullscreen_pause ? NSControlStateValueOn : NSControlStateValueOff];
+  [g_fps setState:g_state.show_fps ? NSControlStateValueOn : NSControlStateValueOff];
 }
 
 } // namespace
@@ -81,9 +74,11 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
   g_callbacks = callbacks;
   @autoreleasepool {
     g_target = [TrayTarget new];
-    g_item = [[NSStatusBar systemStatusBar]
-        statusItemWithLength:NSVariableStatusItemLength];
-    [g_item.button setTitle:@"🦎"];
+    g_item = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
+    NSData *iconData = [NSData dataWithBytes:lizard::assets::lizard_regular_png
+                                      length:lizard::assets::lizard_regular_png_len];
+    NSImage *icon = [[NSImage alloc] initWithData:iconData];
+    [g_item.button setImage:icon];
     g_menu = [[NSMenu alloc] initWithTitle:@""];
     g_enabled = [[NSMenuItem alloc] initWithTitle:@"Enabled"
                                            action:@selector(toggleEnabled:)
@@ -93,10 +88,9 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
                                         action:@selector(toggleMute:)
                                  keyEquivalent:@""];
     [g_mute setTarget:g_target];
-    g_fullscreen =
-        [[NSMenuItem alloc] initWithTitle:@"Pause in Fullscreen"
-                                   action:@selector(toggleFullscreen:)
-                            keyEquivalent:@""];
+    g_fullscreen = [[NSMenuItem alloc] initWithTitle:@"Pause in Fullscreen"
+                                              action:@selector(toggleFullscreen:)
+                                       keyEquivalent:@""];
     [g_fullscreen setTarget:g_target];
     g_fps = [[NSMenuItem alloc] initWithTitle:@"Show FPS"
                                        action:@selector(toggleFPS:)


### PR DESCRIPTION
## Summary
- reuse embedded `lizard-regular.png` for the macOS tray icon
- bundle tray icon via existing assets and document its inclusion

## Testing
- `clang-format --dry-run --Werror assets/embedded.h src/platform/mac/tray.mm`
- `cmake --build build --target lint` *(fails: code should be clang-formatted in existing sources)*
- `clang-tidy src/platform/mac/tray.mm -p build`


------
https://chatgpt.com/codex/tasks/task_e_68a25b1a36188325b8ebffab32d8fd79