### PR TITLE
Cap overlay badge list to configured maximum

### DIFF
--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -11,7 +11,8 @@
   // Maximum simultaneous sound playbacks (default: 4)
   "max_concurrent_playbacks": 4,
 
-  // Limit on badge spawns per second (default: 12)
+  // Limit on badge spawns per second and maximum badges visible at once
+  // (oldest badges are dropped when exceeded, default: 12)
   "badges_per_second_max": 12,
 
   // Minimum badge size in pixels (default: 60)

--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -77,6 +77,7 @@ private:
 
   platform::Window m_window{};
   std::vector<Badge> m_badges;
+  std::size_t m_badge_capacity = 0;
   std::vector<float> m_instanceData;
   std::vector<Sprite> m_sprites;
   std::unordered_map<std::string, int> m_sprite_lookup;
@@ -291,8 +292,9 @@ bool Overlay::init(const app::Config &cfg, std::optional<std::filesystem::path> 
   m_selector = std::discrete_distribution<>(weights.begin(), weights.end());
 
   auto badge_capacity = std::max(1, cfg.badges_per_second_max());
-  m_badges.reserve(static_cast<std::size_t>(badge_capacity));
-  m_instanceData.reserve(static_cast<std::size_t>(badge_capacity) * 9);
+  m_badge_capacity = static_cast<std::size_t>(badge_capacity);
+  m_badges.reserve(m_badge_capacity);
+  m_instanceData.reserve(m_badge_capacity * 9);
 
   if (!m_sprites.empty()) {
     spawn_badge(select_sprite(), 0.0f, 0.0f);
@@ -476,6 +478,9 @@ int Overlay::select_sprite() {
 }
 
 void Overlay::spawn_badge(int sprite, float x, float y) {
+  if (m_badges.size() >= m_badge_capacity && !m_badges.empty()) {
+    m_badges.erase(m_badges.begin());
+  }
   m_badges.emplace_back(Badge{x, y, 0.1f, 1.0f, 0.0f, 1.0f, sprite});
 }
 


### PR DESCRIPTION
## Summary
- enforce badge limit by dropping oldest entries when the overlay reaches the configured maximum
- clarify `badges_per_second_max` also caps simultaneous badge count in sample config

## Testing
- `cmake --preset linux` *(fails: dependency clone stalled)*
- `ctest --test-dir build/linux` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2611747848325a872898045c994b5