### PR TITLE
Log atlas parse errors and test fallback

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,8 +84,8 @@ To override these defaults at runtime, set `sound_path` and `emoji_path` in the
 `lizard.json` configuration file to point to external files. When these paths
 are provided, external assets will be loaded instead of the embedded ones. For
 `emoji_path`, the overlay looks for sprite coordinates in `<emoji_path>.json` or
-an `emoji_atlas.json` file in the same directory. If neither is found, the
-embedded atlas is used.
+an `emoji_atlas.json` file in the same directory. If the atlas is missing or
+invalid, the embedded defaults are used and an error is logged.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- log emoji atlas parse failures and default to builtin sprite
- cover invalid atlas in overlay unit tests and capture log output
- document atlas fallback behavior in README

## Testing
- `cmake -S . -B build` *(fails: libvorbisfile not found, later compile errors)*
- `cmake --build build --target test` *(fails: compile errors in audio engine, missing test executables)*
- `cmake --build build --target lint` *(fails: formatting issues in unrelated tray sources)*

------
https://chatgpt.com/codex/tasks/task_e_68a26121107483259acaeedb1f23a267