### PR TITLE
Add configurable keyboard hook filtering

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -79,14 +79,16 @@ int main(int argc, char **argv) {
                                                  [&]() { running = false; }};
   lizard::platform::init_tray(tray_state, tray_callbacks);
 
-  auto hook = hook::KeyboardHook::create([&](int /*key*/, bool pressed) {
-    if (pressed && cfg.enabled()) {
-      if (!cfg.mute()) {
-        engine.play();
-      }
-      overlay.spawn_badge(0, 0.5f, 0.5f);
-    }
-  });
+  auto hook = hook::KeyboardHook::create(
+      [&](int /*key*/, bool pressed) {
+        if (pressed && cfg.enabled()) {
+          if (!cfg.mute()) {
+            engine.play();
+          }
+          overlay.spawn_badge(0, 0.5f, 0.5f);
+        }
+      },
+      cfg);
   hook->start();
 
   std::jthread reload_thread([&](std::stop_token st) {

--- a/src/hook/CMakeLists.txt
+++ b/src/hook/CMakeLists.txt
@@ -1,18 +1,24 @@
 add_library(lizard_hook STATIC)
 
 # Allow includes like <hook/keyboard_hook.h>
-target_include_directories(lizard_hook PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(lizard_hook PUBLIC
+    ${CMAKE_SOURCE_DIR}/src
+)
+
 target_link_libraries(lizard_hook PUBLIC spdlog::spdlog)
 
+target_sources(lizard_hook PRIVATE filter.cpp)
+
 if (WIN32)
-  target_sources(lizard_hook PRIVATE windows/keyboard_hook.cpp)
-  target_link_libraries(lizard_hook PRIVATE user32)
-elseif(APPLE)
-  target_sources(lizard_hook PRIVATE mac/keyboard_hook.mm)
-  target_link_libraries(lizard_hook PRIVATE "-framework ApplicationServices")
-elseif(UNIX)
-  find_package(X11 REQUIRED)
-  target_sources(lizard_hook PRIVATE linux/keyboard_hook.cpp)
-  target_link_libraries(lizard_hook PRIVATE X11 Xi Xtst)
+    target_sources(lizard_hook PRIVATE windows/keyboard_hook.cpp)
+    target_link_libraries(lizard_hook PRIVATE user32)
+elif (APPLE)
+    target_sources(lizard_hook PRIVATE mac/keyboard_hook.mm)
+    target_link_libraries(lizard_hook PRIVATE "-framework ApplicationServices")
+elif (UNIX)
+    find_package(X11 REQUIRED)
+    target_sources(lizard_hook PRIVATE linux/keyboard_hook.cpp)
+    target_link_libraries(lizard_hook PRIVATE X11 Xi Xtst)
 endif()
+
 add_warning_flags(lizard_hook)

--- a/src/hook/filter.cpp
+++ b/src/hook/filter.cpp
@@ -1,0 +1,33 @@
+#include "hook/filter.h"
+
+#include "app/config.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace hook {
+
+namespace {
+std::string to_lower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return s;
+}
+} // namespace
+
+bool should_deliver_event(const lizard::app::Config &cfg, bool injected,
+                          const std::string &process_name) {
+  if (cfg.ignore_injected() && injected) {
+    return false;
+  }
+  auto excludes = cfg.exclude_processes();
+  std::string proc_lower = to_lower(process_name);
+  for (const auto &name : excludes) {
+    if (to_lower(name) == proc_lower) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace hook

--- a/src/hook/filter.h
+++ b/src/hook/filter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+namespace lizard::app {
+class Config;
+}
+
+namespace hook {
+
+// Returns true if an event should be delivered to callbacks based on config
+// settings. `injected` indicates whether the event was synthetically
+// generated. `process_name` is the executable name of the originating
+// process.
+bool should_deliver_event(const lizard::app::Config &cfg, bool injected,
+                          const std::string &process_name);
+
+} // namespace hook

--- a/src/hook/keyboard_hook.h
+++ b/src/hook/keyboard_hook.h
@@ -3,6 +3,10 @@
 #include <functional>
 #include <memory>
 
+namespace lizard::app {
+class Config;
+}
+
 namespace hook {
 
 // Callback invoked for each key event.
@@ -22,7 +26,7 @@ public:
   virtual void stop() = 0;
 
   // Factory to create a platform-appropriate hook implementation.
-  static std::unique_ptr<KeyboardHook> create(KeyCallback callback);
+  static std::unique_ptr<KeyboardHook> create(KeyCallback callback, const lizard::app::Config &cfg);
 };
 
 } // namespace hook

--- a/src/hook/windows/keyboard_hook.cpp
+++ b/src/hook/windows/keyboard_hook.cpp
@@ -1,10 +1,15 @@
 #include "hook/keyboard_hook.h"
+#include "hook/filter.h"
+
+#include "app/config.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #include <future>
 #include <thread>
+#include <filesystem>
+#include <string>
 
 #include <spdlog/spdlog.h>
 
@@ -16,7 +21,8 @@ using SetHookFn = HHOOK(WINAPI *)(int, HOOKPROC, HINSTANCE, DWORD);
 
 class WindowsKeyboardHook : public KeyboardHook {
 public:
-  explicit WindowsKeyboardHook(KeyCallback cb) : callback_(std::move(cb)) {}
+  WindowsKeyboardHook(KeyCallback cb, const lizard::app::Config &cfg)
+      : callback_(std::move(cb)), config_(cfg) {}
   ~WindowsKeyboardHook() override { stop(); }
 
   bool start() override {
@@ -51,6 +57,11 @@ private:
     if (code == HC_ACTION && instance_) {
       const auto *info = reinterpret_cast<KBDLLHOOKSTRUCT *>(lParam);
       bool pressed = wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN;
+      bool injected = (info->flags & LLKHF_INJECTED) != 0;
+      std::string proc = process_name_();
+      if (!should_deliver_event(instance_->config_, injected, proc)) {
+        return CallNextHookEx(nullptr, code, wParam, lParam);
+      }
       instance_->callback_(static_cast<int>(info->vkCode), pressed);
     }
     return CallNextHookEx(nullptr, code, wParam, lParam);
@@ -75,27 +86,62 @@ private:
   }
 
   KeyCallback callback_;
+  const lizard::app::Config &config_;
   std::jthread thread_;
   DWORD thread_id_{0};
   HHOOK hook_{nullptr};
   bool running_{false};
   static inline WindowsKeyboardHook *instance_{nullptr};
   static inline SetHookFn set_hook_ = &SetWindowsHookExW;
+  using ProcessNameFn = std::string (*)();
+#ifdef LIZARD_TEST
+  static inline ProcessNameFn process_name_ = []() { return std::string(); };
+#else
+  static std::string default_process_name() {
+    std::string name;
+    HWND hwnd = GetForegroundWindow();
+    if (!hwnd) {
+      return name;
+    }
+    DWORD pid = 0;
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (!pid) {
+      return name;
+    }
+    HANDLE proc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!proc) {
+      return name;
+    }
+    wchar_t path[MAX_PATH];
+    DWORD size = MAX_PATH;
+    if (QueryFullProcessImageNameW(proc, 0, path, &size)) {
+      name = std::filesystem::path(path).filename().string();
+    }
+    CloseHandle(proc);
+    return name;
+  }
+  static inline ProcessNameFn process_name_ = &default_process_name;
+#endif
 #ifdef LIZARD_TEST
   friend void testing::set_setwindows_hook_ex(SetHookFn);
+  friend void testing::set_process_name_resolver(ProcessNameFn);
 #endif
 };
 
 #ifdef LIZARD_TEST
 namespace testing {
 inline void set_setwindows_hook_ex(SetHookFn fn) { WindowsKeyboardHook::set_hook_ = fn; }
+inline void set_process_name_resolver(WindowsKeyboardHook::ProcessNameFn fn) {
+  WindowsKeyboardHook::process_name_ = fn;
+}
 } // namespace testing
 #endif
 
 } // namespace
 
-std::unique_ptr<KeyboardHook> KeyboardHook::create(KeyCallback callback) {
-  return std::make_unique<WindowsKeyboardHook>(std::move(callback));
+std::unique_ptr<KeyboardHook> KeyboardHook::create(KeyCallback callback,
+                                                   const lizard::app::Config &cfg) {
+  return std::make_unique<WindowsKeyboardHook>(std::move(callback), cfg);
 }
 
 } // namespace hook


### PR DESCRIPTION
## Summary
- pass Config into hook factories so platform hooks can filter events
- drop injected keystrokes and exclude named processes across platforms
- add tests for new filtering logic
- fix hook CMake script formatting so CMake can configure

## Testing
- `clang-format --dry-run src/app/main.cpp src/hook/filter.cpp src/hook/filter.h src/hook/keyboard_hook.h src/hook/linux/keyboard_hook.cpp src/hook/mac/keyboard_hook.mm src/hook/windows/keyboard_hook.cpp src/tests/hook_tests.cpp`
- `cmake -S . -B build -GNinja`
- `cmake --build build` *(fails: GL_TIMEOUT_IGNORED redefined and unused parameter 'win')*
- `ctest --test-dir build` *(fails: test executables not found after build failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c10312c48325bc34aef543b1dfb7