### PR TITLE
Resolve relative asset paths

### DIFF
--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -145,22 +145,28 @@ void Config::load(std::unique_lock<std::shared_mutex> &lock) {
     }
 
     if (j.contains("sound_path")) {
-      auto path = j.at("sound_path").get<std::string>();
+      auto path = std::filesystem::path(j.at("sound_path").get<std::string>());
       if (path.empty()) {
         sound_path_ = std::nullopt;
       } else {
-        sound_path_ = path;
+        if (!path.is_absolute()) {
+          path = config_path_.parent_path() / path;
+        }
+        sound_path_ = std::move(path);
       }
     } else {
       sound_path_ = std::nullopt;
     }
 
     if (j.contains("emoji_path")) {
-      auto path = j.at("emoji_path").get<std::string>();
+      auto path = std::filesystem::path(j.at("emoji_path").get<std::string>());
       if (path.empty()) {
         emoji_path_ = std::nullopt;
       } else {
-        emoji_path_ = path;
+        if (!path.is_absolute()) {
+          path = config_path_.parent_path() / path;
+        }
+        emoji_path_ = std::move(path);
       }
     } else {
       emoji_path_ = std::nullopt;

--- a/src/tests/config_tests.cpp
+++ b/src/tests/config_tests.cpp
@@ -53,6 +53,25 @@ TEST_CASE("parses asset paths", "[config]") {
   std::filesystem::remove(cfg_file);
 }
 
+TEST_CASE("resolves relative asset paths", "[config]") {
+  auto tempdir = std::filesystem::temp_directory_path() / "lizard_cfg_rel";
+  std::filesystem::create_directories(tempdir);
+  auto cfg_file = tempdir / "lizard_cfg_rel.json";
+  {
+    std::ofstream out(cfg_file);
+    out << R"({"sound_path":"custom.flac","emoji_path":"custom.png"})";
+  }
+
+  Config cfg(tempdir, cfg_file);
+  REQUIRE(cfg.sound_path().has_value());
+  REQUIRE(cfg.emoji_path().has_value());
+  REQUIRE(cfg.sound_path().value() == tempdir / "custom.flac");
+  REQUIRE(cfg.emoji_path().value() == tempdir / "custom.png");
+
+  std::filesystem::remove(cfg_file);
+  std::filesystem::remove_all(tempdir);
+}
+
 TEST_CASE("asset paths reset when removed or empty", "[config]") {
   using namespace std::chrono_literals;
   auto tempdir = std::filesystem::temp_directory_path();


### PR DESCRIPTION
## Summary
- resolve relative sound and emoji paths against the config file directory
- add unit test for relative path resolution

## Testing
- `cmake --preset linux` *(fails: OverlayTestAccess not found)*
- `cmake --build build/linux --target config_tests`
- `ctest --test-dir build/linux -R config`
- `clang-tidy src/app/config.cpp src/tests/config_tests.cpp -p build/linux` *(fails: unknown key 'AnalyzeTemporaryDtors')*


------
https://chatgpt.com/codex/tasks/task_e_68a74ff0d69883258932e71f26379109