### PR TITLE
feat: add log path option

### DIFF
--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -54,6 +54,9 @@
   // Logging verbosity ("trace", "debug", "info", "warn", "error", default: "info")
   "logging_level": "info",
 
+  // Log file path (default: config directory)
+  "logging_path": "",
+
   // Asynchronous logging queue size (default: 8192)
   "logging_queue_size": 8192,
 

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,9 @@ Common options include:
 - `exclude_processes` to ignore specific executables
 - `sound_path` and `emoji_path` for external assets
 - `logging_level` to control verbosity
+- `logging_path` to set the log file location
+
+Invalid `logging_level` values log a warning and fall back to `info`.
 
 Configuration values are loaded from the first location that exists:
 

--- a/src/app/config.h
+++ b/src/app/config.h
@@ -41,6 +41,7 @@ public:
   std::string logging_level() const;
   int logging_queue_size() const;
   int logging_worker_count() const;
+  std::filesystem::path logging_path() const;
 
   std::condition_variable &reload_cv() { return reload_cv_; }
 
@@ -79,6 +80,7 @@ private:
   std::string logging_level_{"info"};
   int logging_queue_size_{8192};
   int logging_worker_count_{1};
+  std::filesystem::path logging_path_{};
 };
 
 } // namespace lizard::app

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
   auto workers = result.count("log-workers")
                      ? static_cast<std::size_t>(result["log-workers"].as<int>())
                      : static_cast<std::size_t>(cfg.logging_worker_count());
-  lizard::util::init_logging(level, queue, workers);
+  lizard::util::init_logging(level, queue, workers, cfg.logging_path());
 
   lizard::audio::Engine engine(static_cast<std::uint32_t>(cfg.max_concurrent_playbacks()),
                                std::chrono::milliseconds(cfg.sound_cooldown_ms()));

--- a/src/tests/log_tests.cpp
+++ b/src/tests/log_tests.cpp
@@ -13,7 +13,7 @@ TEST_CASE("logs rotate", "[log]") {
   remove("lizard.log");
   remove("lizard.1.log");
 
-  lizard::util::init_logging("info", 8192, 1);
+  lizard::util::init_logging("info", 8192, 1, tempdir / "lizard.log");
 
   std::string big(1024, 'x');
   for (int i = 0; i < 6000; ++i) {
@@ -26,5 +26,15 @@ TEST_CASE("logs rotate", "[log]") {
   REQUIRE(exists("lizard.1.log"));
 
   current_path(prev);
+  remove_all(tempdir);
+}
+
+TEST_CASE("invalid level defaults to info", "[log]") {
+  using namespace std::filesystem;
+  auto tempdir = temp_directory_path() / "lizard_log_level";
+  create_directories(tempdir);
+  lizard::util::init_logging("bogus", 8192, 1, tempdir / "lizard.log");
+  REQUIRE(spdlog::default_logger()->level() == spdlog::level::info);
+  spdlog::shutdown();
   remove_all(tempdir);
 }

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -6,16 +6,19 @@
 
 namespace lizard::util {
 
-void init_logging(std::string_view level, std::size_t queue_size, std::size_t worker_count) {
+void init_logging(std::string_view level, std::size_t queue_size, std::size_t worker_count,
+                  std::optional<std::filesystem::path> file_path) {
   auto logger = spdlog::get("lizard");
   if (!logger) {
     spdlog::init_thread_pool(queue_size, worker_count);
-    logger = spdlog::rotating_logger_mt<spdlog::async_factory>("lizard", "lizard.log",
-                                                               1024 * 1024 * 5, 3);
+    auto path = file_path.value_or("lizard.log");
+    logger = spdlog::rotating_logger_mt<spdlog::async_factory>(
+        "lizard", path.string(), 1024 * 1024 * 5, 3);
   }
   spdlog::set_default_logger(logger);
   auto lvl = spdlog::level::from_str(std::string(level));
   if (lvl == spdlog::level::off && level != "off") {
+    spdlog::warn("Invalid log level '{}'; defaulting to info", level);
     lvl = spdlog::level::info;
   }
   spdlog::set_level(lvl);

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <cstddef>
+#include <filesystem>
+#include <optional>
 #include <string_view>
 
 namespace lizard::util {
 
-void init_logging(std::string_view level, std::size_t queue_size, std::size_t worker_count);
+void init_logging(std::string_view level, std::size_t queue_size, std::size_t worker_count,
+                  std::optional<std::filesystem::path> file_path = std::nullopt);
 
 } // namespace lizard::util


### PR DESCRIPTION
## Summary
- allow init_logging to take optional log file path and warn on invalid levels
- parse and forward logging_path from configuration
- document logging_path and level fallback

## Testing
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --preset linux` *(after installing deps)*
- `cmake --build build/linux` *(fails: OpenGL header already included and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a74fefcf348325add806ec19bee52f