### PR TITLE
Pause overlay in fullscreen

### DIFF
--- a/src/platform/win/window.cpp
+++ b/src/platform/win/window.cpp
@@ -97,6 +97,24 @@ void poll_events(Window &window) {
   }
 }
 
+bool fullscreen_window_present() {
+  HWND hwnd = GetForegroundWindow();
+  if (!hwnd || hwnd == g_hwnd) {
+    return false;
+  }
+  RECT rect{};
+  if (!GetWindowRect(hwnd, &rect)) {
+    return false;
+  }
+  HMONITOR mon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
+  MONITORINFO mi{sizeof(mi)};
+  if (!GetMonitorInfo(mon, &mi)) {
+    return false;
+  }
+  return rect.left <= mi.rcMonitor.left && rect.top <= mi.rcMonitor.top &&
+         rect.right >= mi.rcMonitor.right && rect.bottom >= mi.rcMonitor.bottom;
+}
+
 } // namespace lizard::platform
 
 #endif

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -35,5 +35,6 @@ struct Window {
 Window create_overlay_window(const WindowDesc &desc);
 void destroy_window(Window &window);
 void poll_events(Window &window);
+bool fullscreen_window_present();
 
 } // namespace lizard::platform


### PR DESCRIPTION
## Summary
- add per-OS helper to detect topmost fullscreen windows
- periodically check fullscreen and pause overlay/audio when enabled

## Testing
- `clang-format --dry-run src/app/main.cpp src/overlay/overlay.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/platform/win/window.cpp src/platform/window.hpp`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a89ff2e9808325ae189e72401e0622