### PR TITLE
Add configurable frame rate and auto refresh detection

### DIFF
--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -51,6 +51,13 @@
   // DPI scaling mode (e.g., "per_monitor_v2", default: "per_monitor_v2")
   "dpi_scaling_mode": "per_monitor_v2",
 
+  // Frame rate mode: "auto" matches the monitor's refresh rate,
+  // "fixed" uses the value of `fps_fixed`.
+  "fps_mode": "auto",
+
+  // Fixed frame rate in Hz when `fps_mode` is "fixed" (default: 60)
+  "fps_fixed": 60,
+
   // Logging verbosity ("trace", "debug", "info", "warn", "error", default: "info")
   "logging_level": "info",
 

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -147,6 +147,13 @@ void Config::load(std::unique_lock<std::shared_mutex> &lock) {
     }
     logging_path_ = j.value("logging_path", logging_path_.string());
 
+    fps_mode_ = j.value("fps_mode", std::string("auto"));
+    fps_fixed_ = clamp_nonneg(j.value("fps_fixed", 60), "fps_fixed");
+    if (fps_fixed_ == 0) {
+      spdlog::warn("fps_fixed zero; clamping to 1");
+      fps_fixed_ = 1;
+    }
+
     if (j.contains("sound_path")) {
       auto path = std::filesystem::path(j.at("sound_path").get<std::string>());
       if (path.empty()) {
@@ -301,6 +308,16 @@ int Config::logging_worker_count() const {
 std::filesystem::path Config::logging_path() const {
   std::shared_lock lock(mutex_);
   return logging_path_;
+}
+
+std::string Config::fps_mode() const {
+  std::shared_lock lock(mutex_);
+  return fps_mode_;
+}
+
+int Config::fps_fixed() const {
+  std::shared_lock lock(mutex_);
+  return fps_fixed_;
 }
 
 } // namespace lizard::app

--- a/src/app/config.h
+++ b/src/app/config.h
@@ -42,6 +42,8 @@ public:
   int logging_queue_size() const;
   int logging_worker_count() const;
   std::filesystem::path logging_path() const;
+  std::string fps_mode() const;
+  int fps_fixed() const;
 
   std::condition_variable &reload_cv() { return reload_cv_; }
 
@@ -81,6 +83,8 @@ private:
   int logging_queue_size_{8192};
   int logging_worker_count_{1};
   std::filesystem::path logging_path_{};
+  std::string fps_mode_{"auto"};
+  int fps_fixed_{60};
 };
 
 } // namespace lizard::app


### PR DESCRIPTION
## Summary
- add `fps_mode` and `fps_fixed` config settings with defaults and JSON parsing
- determine frame interval at overlay init, querying monitor refresh on each platform
- use computed frame interval in render loop instead of fixed 60 Hz; document fields in sample config

## Testing
- `clang-format --dry-run src/overlay/overlay.cpp src/app/config.cpp src/app/config.h`
- `cmake --preset linux` *(fails: field `m_buffer` incomplete and missing `<iostream>` in main.cpp)*
- `clang-tidy src/app/config.cpp src/app/config.h src/overlay/overlay.cpp -- -Iinclude -std=c++20` *(warnings and errors due to repo state)*

------
https://chatgpt.com/codex/tasks/task_e_68a89fef96ac8325b55942d353cb9db3