### PR TITLE
Handle default audio device changes

### DIFF
--- a/src/audio/engine.h
+++ b/src/audio/engine.h
@@ -5,13 +5,17 @@
 #include <filesystem>
 #include <optional>
 #include <string_view>
+#include <string>
 #include <vector>
+#include <mutex>
 
 struct ma_engine;
 struct ma_context;
 struct ma_audio_buffer_config;
 struct ma_audio_buffer;
 struct ma_sound;
+enum ma_device_type;
+typedef unsigned int ma_endpoint_notification_type; // forward declaration placeholder
 
 namespace lizard::audio {
 
@@ -42,6 +46,13 @@ private:
   std::chrono::steady_clock::time_point m_lastPlay{};
   std::chrono::milliseconds m_cooldown{};
   float m_volume{1.0f};
+  std::optional<std::filesystem::path> m_soundPath{};
+  int m_volumePercent{100};
+  std::string m_backend{"miniaudio"};
+  std::mutex m_mutex;
+
+  static void endpoint_callback(ma_context *pContext, ma_device_type deviceType,
+                                ma_endpoint_notification_type notificationType, void *pUserData);
 };
 
 } // namespace lizard::audio


### PR DESCRIPTION
## Summary
- register miniaudio endpoint notification callback and restart audio engine on default device changes
- protect audio playback and reinitialization with a mutex

## Testing
- `clang-format --dry-run --Werror src/audio/engine.h src/audio/engine.cpp`
- `cmake -S . -B build` *(fails: gtk+-3.0 not found)*
- `clang-tidy src/audio/engine.cpp --quiet -p build` *(fails: compilation database not found)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a44736e483258bdbadd8b7cd5300