### PR TITLE
Add threaded tray with FPS submenu

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -68,26 +68,36 @@ int main(int argc, char **argv) {
   });
 
   std::atomic<bool> running{true};
-  lizard::platform::TrayState tray_state{cfg.enabled(), cfg.mute(), cfg.fullscreen_pause(), false};
-  lizard::platform::TrayCallbacks tray_callbacks{[&](bool v) {
-                                                   tray_state.enabled = v;
-                                                   lizard::platform::update_tray(tray_state);
-                                                 },
-                                                 [&](bool v) {
-                                                   tray_state.muted = v;
-                                                   lizard::platform::update_tray(tray_state);
-                                                 },
-                                                 [&](bool v) {
-                                                   tray_state.fullscreen_pause = v;
-                                                   lizard::platform::update_tray(tray_state);
-                                                 },
-                                                 [&](bool v) {
-                                                   tray_state.show_fps = v;
-                                                   lizard::platform::update_tray(tray_state);
-                                                 },
-                                                 []() {},
-                                                 []() {},
-                                                 [&]() { running = false; }};
+  lizard::platform::TrayState tray_state{cfg.enabled(), cfg.mute(), cfg.fullscreen_pause(),
+                                         lizard::platform::FpsMode::Auto, 60};
+  lizard::platform::TrayCallbacks tray_callbacks{
+      [&](bool v) {
+        tray_state.enabled = v;
+        lizard::platform::update_tray(tray_state);
+      },
+      [&](bool v) {
+        tray_state.muted = v;
+        lizard::platform::update_tray(tray_state);
+      },
+      [&](bool v) {
+        tray_state.fullscreen_pause = v;
+        lizard::platform::update_tray(tray_state);
+      },
+      [&](lizard::platform::FpsMode m) {
+        tray_state.fps_mode = m;
+        overlay.set_fps_mode(m);
+        lizard::platform::update_tray(tray_state);
+      },
+      [&](int v) {
+        tray_state.fps_mode = lizard::platform::FpsMode::Fixed;
+        tray_state.fps_fixed = v;
+        overlay.set_fps_mode(lizard::platform::FpsMode::Fixed);
+        overlay.set_fps_fixed(v);
+        lizard::platform::update_tray(tray_state);
+      },
+      []() {},
+      []() {},
+      [&]() { running = false; }};
   lizard::platform::init_tray(tray_state, tray_callbacks);
 
   auto hook = hook::KeyboardHook::create(

--- a/src/platform/linux/tray.cpp
+++ b/src/platform/linux/tray.cpp
@@ -12,6 +12,8 @@
 #endif
 
 #include <gtk/gtk.h>
+#include <future>
+#include <thread>
 
 namespace lizard::platform {
 
@@ -23,9 +25,19 @@ GtkWidget *g_item_enabled = nullptr;
 GtkWidget *g_item_mute = nullptr;
 GtkWidget *g_item_fullscreen = nullptr;
 GtkWidget *g_item_fps = nullptr;
+GtkWidget *g_item_fps_auto = nullptr;
+GtkWidget *g_item_fps_fixed_60 = nullptr;
+GtkWidget *g_item_fps_fixed_75 = nullptr;
+GtkWidget *g_item_fps_fixed_120 = nullptr;
+GtkWidget *g_item_fps_fixed_144 = nullptr;
+GtkWidget *g_item_fps_fixed_165 = nullptr;
+GtkWidget *g_item_fps_fixed_240 = nullptr;
 GtkWidget *g_item_config = nullptr;
 GtkWidget *g_item_logs = nullptr;
 GtkWidget *g_item_quit = nullptr;
+GtkWidget *g_menu_fps = nullptr;
+GtkWidget *g_menu_fps_fixed = nullptr;
+std::jthread g_thread;
 #ifdef LIZARD_HAVE_APPINDICATOR
 AppIndicator *g_indicator = nullptr;
 #else
@@ -33,14 +45,23 @@ GtkStatusIcon *g_status_icon = nullptr;
 #endif
 
 void update_menu() {
-  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_enabled),
-                                 g_state.enabled);
-  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_mute),
-                                 g_state.muted);
-  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fullscreen),
-                                 g_state.fullscreen_pause);
-  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps),
-                                 g_state.show_fps);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_enabled), g_state.enabled);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_mute), g_state.muted);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fullscreen), g_state.fullscreen_pause);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps_auto),
+                                 g_state.fps_mode == FpsMode::Auto);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps_fixed_60),
+                                 g_state.fps_mode == FpsMode::Fixed && g_state.fps_fixed == 60);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps_fixed_75),
+                                 g_state.fps_mode == FpsMode::Fixed && g_state.fps_fixed == 75);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps_fixed_120),
+                                 g_state.fps_mode == FpsMode::Fixed && g_state.fps_fixed == 120);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps_fixed_144),
+                                 g_state.fps_mode == FpsMode::Fixed && g_state.fps_fixed == 144);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps_fixed_165),
+                                 g_state.fps_mode == FpsMode::Fixed && g_state.fps_fixed == 165);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(g_item_fps_fixed_240),
+                                 g_state.fps_mode == FpsMode::Fixed && g_state.fps_fixed == 240);
 }
 
 void on_enabled(GtkWidget *, gpointer) {
@@ -61,10 +82,19 @@ void on_fullscreen(GtkWidget *, gpointer) {
     g_callbacks.toggle_fullscreen_pause(g_state.fullscreen_pause);
   update_menu();
 }
-void on_fps(GtkWidget *, gpointer) {
-  g_state.show_fps = !g_state.show_fps;
-  if (g_callbacks.toggle_fps)
-    g_callbacks.toggle_fps(g_state.show_fps);
+void on_fps_auto(GtkWidget *, gpointer) {
+  g_state.fps_mode = FpsMode::Auto;
+  if (g_callbacks.set_fps_mode)
+    g_callbacks.set_fps_mode(FpsMode::Auto);
+  update_menu();
+}
+void on_fps_fixed(GtkWidget *, gpointer data) {
+  g_state.fps_mode = FpsMode::Fixed;
+  g_state.fps_fixed = GPOINTER_TO_INT(data);
+  if (g_callbacks.set_fps_mode)
+    g_callbacks.set_fps_mode(FpsMode::Fixed);
+  if (g_callbacks.set_fps_fixed)
+    g_callbacks.set_fps_fixed(g_state.fps_fixed);
   update_menu();
 }
 void on_config(GtkWidget *, gpointer) {
@@ -80,16 +110,12 @@ void on_quit(GtkWidget *, gpointer) {
     g_callbacks.quit();
 }
 #ifndef LIZARD_HAVE_APPINDICATOR
-void on_popup(GtkStatusIcon *, guint button, guint activate_time, gpointer) {
+void on_popup(GtkStatusIcon *, guint, guint, gpointer) {
   gtk_menu_popup_at_pointer(GTK_MENU(g_menu), nullptr);
 }
 #endif
 
-} // namespace
-
-bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
-  g_state = state;
-  g_callbacks = callbacks;
+bool init_thread() {
   int argc = 0;
   char **argv = nullptr;
   gtk_init(&argc, &argv);
@@ -102,12 +128,49 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
   g_signal_connect(g_item_mute, "activate", G_CALLBACK(on_mute), nullptr);
   gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_mute);
   g_item_fullscreen = gtk_check_menu_item_new_with_label("Pause in Fullscreen");
-  g_signal_connect(g_item_fullscreen, "activate", G_CALLBACK(on_fullscreen),
-                   nullptr);
+  g_signal_connect(g_item_fullscreen, "activate", G_CALLBACK(on_fullscreen), nullptr);
   gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_fullscreen);
-  g_item_fps = gtk_check_menu_item_new_with_label("Show FPS");
-  g_signal_connect(g_item_fps, "activate", G_CALLBACK(on_fps), nullptr);
+
+  g_menu_fps = gtk_menu_new();
+  g_menu_fps_fixed = gtk_menu_new();
+  g_item_fps_auto = gtk_radio_menu_item_new_with_label(nullptr, "Auto");
+  g_signal_connect(g_item_fps_auto, "activate", G_CALLBACK(on_fps_auto), nullptr);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps), g_item_fps_auto);
+  g_item_fps_fixed_60 =
+      gtk_radio_menu_item_new_with_label_from_widget(GTK_RADIO_MENU_ITEM(g_item_fps_auto), "60");
+  g_signal_connect(g_item_fps_fixed_60, "activate", G_CALLBACK(on_fps_fixed), GINT_TO_POINTER(60));
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps_fixed), g_item_fps_fixed_60);
+  g_item_fps_fixed_75 =
+      gtk_radio_menu_item_new_with_label_from_widget(GTK_RADIO_MENU_ITEM(g_item_fps_auto), "75");
+  g_signal_connect(g_item_fps_fixed_75, "activate", G_CALLBACK(on_fps_fixed), GINT_TO_POINTER(75));
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps_fixed), g_item_fps_fixed_75);
+  g_item_fps_fixed_120 =
+      gtk_radio_menu_item_new_with_label_from_widget(GTK_RADIO_MENU_ITEM(g_item_fps_auto), "120");
+  g_signal_connect(g_item_fps_fixed_120, "activate", G_CALLBACK(on_fps_fixed),
+                   GINT_TO_POINTER(120));
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps_fixed), g_item_fps_fixed_120);
+  g_item_fps_fixed_144 =
+      gtk_radio_menu_item_new_with_label_from_widget(GTK_RADIO_MENU_ITEM(g_item_fps_auto), "144");
+  g_signal_connect(g_item_fps_fixed_144, "activate", G_CALLBACK(on_fps_fixed),
+                   GINT_TO_POINTER(144));
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps_fixed), g_item_fps_fixed_144);
+  g_item_fps_fixed_165 =
+      gtk_radio_menu_item_new_with_label_from_widget(GTK_RADIO_MENU_ITEM(g_item_fps_auto), "165");
+  g_signal_connect(g_item_fps_fixed_165, "activate", G_CALLBACK(on_fps_fixed),
+                   GINT_TO_POINTER(165));
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps_fixed), g_item_fps_fixed_165);
+  g_item_fps_fixed_240 =
+      gtk_radio_menu_item_new_with_label_from_widget(GTK_RADIO_MENU_ITEM(g_item_fps_auto), "240");
+  g_signal_connect(g_item_fps_fixed_240, "activate", G_CALLBACK(on_fps_fixed),
+                   GINT_TO_POINTER(240));
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps_fixed), g_item_fps_fixed_240);
+  GtkWidget *fixed = gtk_menu_item_new_with_label("Fixed");
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(fixed), g_menu_fps_fixed);
+  gtk_menu_shell_append(GTK_MENU_SHELL(g_menu_fps), fixed);
+  g_item_fps = gtk_menu_item_new_with_label("FPS");
+  gtk_menu_item_set_submenu(GTK_MENU_ITEM(g_item_fps), g_menu_fps);
   gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), g_item_fps);
+
   gtk_menu_shell_append(GTK_MENU_SHELL(g_menu), gtk_separator_menu_item_new());
   g_item_config = gtk_menu_item_new_with_label("Open Config");
   g_signal_connect(g_item_config, "activate", G_CALLBACK(on_config), nullptr);
@@ -122,8 +185,8 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
   gtk_widget_show_all(g_menu);
 
 #ifdef LIZARD_HAVE_APPINDICATOR
-  g_indicator = app_indicator_new("lizard", "indicator-messages",
-                                  APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+  g_indicator =
+      app_indicator_new("lizard", "indicator-messages", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
   app_indicator_set_menu(g_indicator, GTK_MENU(g_menu));
   app_indicator_set_status(g_indicator, APP_INDICATOR_STATUS_ACTIVE);
 #else
@@ -131,8 +194,8 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
   g_signal_connect(g_status_icon, "popup-menu", G_CALLBACK(on_popup), nullptr);
   gtk_status_icon_set_visible(g_status_icon, TRUE);
   gtk_status_icon_set_has_tooltip(g_status_icon, TRUE);
-    gtk_status_icon_set_tooltip_text(g_status_icon, "Lizard Hook");
-    gtk_status_icon_set_title(g_status_icon, "Lizard Hook");
+  gtk_status_icon_set_tooltip_text(g_status_icon, "Lizard Hook");
+  gtk_status_icon_set_title(g_status_icon, "Lizard Hook");
   gtk_status_icon_set_name(g_status_icon, "lizard");
   gtk_status_icon_set_from_icon_name(g_status_icon, "indicator-messages");
 #endif
@@ -141,12 +204,7 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
   return true;
 }
 
-void update_tray(const TrayState &state) {
-  g_state = state;
-  update_menu();
-}
-
-void shutdown_tray() {
+void shutdown_thread() {
 #ifdef LIZARD_HAVE_APPINDICATOR
   if (g_indicator) {
     app_indicator_set_status(g_indicator, APP_INDICATOR_STATUS_PASSIVE);
@@ -162,6 +220,47 @@ void shutdown_tray() {
     gtk_widget_destroy(g_menu);
     g_menu = nullptr;
   }
+}
+
+void tray_thread(std::stop_token st, std::promise<bool> ready) {
+  bool ok = init_thread();
+  ready.set_value(ok);
+  if (!ok)
+    return;
+  gtk_main();
+  shutdown_thread();
+}
+
+} // namespace
+
+bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
+  g_state = state;
+  g_callbacks = callbacks;
+  std::promise<bool> ready;
+  auto fut = ready.get_future();
+  g_thread = std::jthread(tray_thread, std::move(ready));
+  return fut.get();
+}
+
+void update_tray(const TrayState &state) {
+  g_state = state;
+  g_idle_add(
+      [](gpointer) -> gboolean {
+        update_menu();
+        return G_SOURCE_REMOVE;
+      },
+      nullptr);
+}
+
+void shutdown_tray() {
+  g_idle_add(
+      [](gpointer) -> gboolean {
+        gtk_main_quit();
+        return G_SOURCE_REMOVE;
+      },
+      nullptr);
+  if (g_thread.joinable())
+    g_thread.join();
 }
 
 } // namespace lizard::platform

--- a/src/platform/tray.hpp
+++ b/src/platform/tray.hpp
@@ -4,18 +4,25 @@
 
 namespace lizard::platform {
 
+enum class FpsMode {
+  Auto,
+  Fixed,
+};
+
 struct TrayState {
   bool enabled = true;
   bool muted = false;
   bool fullscreen_pause = false;
-  bool show_fps = false;
+  FpsMode fps_mode = FpsMode::Auto;
+  int fps_fixed = 60;
 };
 
 struct TrayCallbacks {
   std::function<void(bool)> toggle_enabled;
   std::function<void(bool)> toggle_mute;
   std::function<void(bool)> toggle_fullscreen_pause;
-  std::function<void(bool)> toggle_fps;
+  std::function<void(FpsMode)> set_fps_mode;
+  std::function<void(int)> set_fps_fixed;
   std::function<void()> open_config;
   std::function<void()> open_logs;
   std::function<void()> quit;

--- a/src/platform/win/tray.cpp
+++ b/src/platform/win/tray.cpp
@@ -7,21 +7,36 @@
 #include <spdlog/spdlog.h>
 #include <windows.h>
 
+#include <future>
+#include <mutex>
+#include <thread>
+
 namespace lizard::platform {
 
 namespace {
 TrayState g_state;
 TrayCallbacks g_callbacks;
+std::mutex g_mutex;
 HWND g_hwnd = nullptr;
 HMENU g_menu = nullptr;
+HMENU g_fps_menu = nullptr;
+HMENU g_fps_fixed_menu = nullptr;
 NOTIFYICONDATAW g_nid{};
 constexpr UINT WM_TRAY = WM_APP + 1;
+constexpr UINT WM_UPDATE = WM_APP + 2;
+std::jthread g_thread;
 
 enum MenuId {
   ID_ENABLED = 1,
   ID_MUTE,
   ID_FULLSCREEN,
-  ID_FPS,
+  ID_FPS_AUTO,
+  ID_FPS_FIXED_60,
+  ID_FPS_FIXED_75,
+  ID_FPS_FIXED_120,
+  ID_FPS_FIXED_144,
+  ID_FPS_FIXED_165,
+  ID_FPS_FIXED_240,
   ID_CONFIG,
   ID_LOGS,
   ID_QUIT,
@@ -32,7 +47,30 @@ void update_menu() {
   CheckMenuItem(g_menu, ID_MUTE, MF_BYCOMMAND | (g_state.muted ? MF_CHECKED : MF_UNCHECKED));
   CheckMenuItem(g_menu, ID_FULLSCREEN,
                 MF_BYCOMMAND | (g_state.fullscreen_pause ? MF_CHECKED : MF_UNCHECKED));
-  CheckMenuItem(g_menu, ID_FPS, MF_BYCOMMAND | (g_state.show_fps ? MF_CHECKED : MF_UNCHECKED));
+  CheckMenuItem(g_fps_menu, ID_FPS_AUTO,
+                MF_BYCOMMAND | (g_state.fps_mode == FpsMode::Auto ? MF_CHECKED : MF_UNCHECKED));
+  UINT fixed_id = 0;
+  switch (g_state.fps_fixed) {
+  case 60:
+    fixed_id = ID_FPS_FIXED_60;
+    break;
+  case 75:
+    fixed_id = ID_FPS_FIXED_75;
+    break;
+  case 120:
+    fixed_id = ID_FPS_FIXED_120;
+    break;
+  case 144:
+    fixed_id = ID_FPS_FIXED_144;
+    break;
+  case 165:
+    fixed_id = ID_FPS_FIXED_165;
+    break;
+  case 240:
+    fixed_id = ID_FPS_FIXED_240;
+    break;
+  }
+  CheckMenuRadioItem(g_fps_fixed_menu, ID_FPS_FIXED_60, ID_FPS_FIXED_240, fixed_id);
 }
 
 void on_command(UINT id) {
@@ -55,12 +93,38 @@ void on_command(UINT id) {
       g_callbacks.toggle_fullscreen_pause(g_state.fullscreen_pause);
     update_menu();
     break;
-  case ID_FPS:
-    g_state.show_fps = !g_state.show_fps;
-    if (g_callbacks.toggle_fps)
-      g_callbacks.toggle_fps(g_state.show_fps);
+  case ID_FPS_AUTO:
+    g_state.fps_mode = FpsMode::Auto;
+    if (g_callbacks.set_fps_mode)
+      g_callbacks.set_fps_mode(FpsMode::Auto);
     update_menu();
     break;
+  case ID_FPS_FIXED_60:
+  case ID_FPS_FIXED_75:
+  case ID_FPS_FIXED_120:
+  case ID_FPS_FIXED_144:
+  case ID_FPS_FIXED_165:
+  case ID_FPS_FIXED_240: {
+    g_state.fps_mode = FpsMode::Fixed;
+    int val = 60;
+    if (id == ID_FPS_FIXED_75)
+      val = 75;
+    else if (id == ID_FPS_FIXED_120)
+      val = 120;
+    else if (id == ID_FPS_FIXED_144)
+      val = 144;
+    else if (id == ID_FPS_FIXED_165)
+      val = 165;
+    else if (id == ID_FPS_FIXED_240)
+      val = 240;
+    g_state.fps_fixed = val;
+    if (g_callbacks.set_fps_mode)
+      g_callbacks.set_fps_mode(FpsMode::Fixed);
+    if (g_callbacks.set_fps_fixed)
+      g_callbacks.set_fps_fixed(val);
+    update_menu();
+    break;
+  }
   case ID_CONFIG:
     if (g_callbacks.open_config)
       g_callbacks.open_config();
@@ -86,16 +150,17 @@ LRESULT CALLBACK wnd_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
       SetForegroundWindow(hwnd);
       TrackPopupMenu(g_menu, TPM_RIGHTBUTTON, pt.x, pt.y, 0, hwnd, nullptr);
     }
+  } else if (msg == WM_UPDATE) {
+    update_menu();
+    return 0;
+  } else if (msg == WM_DESTROY) {
+    PostQuitMessage(0);
+    return 0;
   }
   return DefWindowProc(hwnd, msg, wParam, lParam);
 }
 
-} // namespace
-
-bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
-  g_state = state;
-  g_callbacks = callbacks;
-
+bool init_thread() {
   WNDCLASSW wc{};
   wc.lpfnWndProc = wnd_proc;
   wc.hInstance = GetModuleHandle(nullptr);
@@ -115,7 +180,19 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
   AppendMenuW(g_menu, MF_STRING, ID_ENABLED, L"Enabled");
   AppendMenuW(g_menu, MF_STRING, ID_MUTE, L"Mute");
   AppendMenuW(g_menu, MF_STRING, ID_FULLSCREEN, L"Pause in Fullscreen");
-  AppendMenuW(g_menu, MF_STRING, ID_FPS, L"Show FPS");
+
+  g_fps_menu = CreatePopupMenu();
+  g_fps_fixed_menu = CreatePopupMenu();
+  AppendMenuW(g_fps_menu, MF_STRING, ID_FPS_AUTO, L"Auto");
+  AppendMenuW(g_fps_fixed_menu, MF_STRING, ID_FPS_FIXED_60, L"60");
+  AppendMenuW(g_fps_fixed_menu, MF_STRING, ID_FPS_FIXED_75, L"75");
+  AppendMenuW(g_fps_fixed_menu, MF_STRING, ID_FPS_FIXED_120, L"120");
+  AppendMenuW(g_fps_fixed_menu, MF_STRING, ID_FPS_FIXED_144, L"144");
+  AppendMenuW(g_fps_fixed_menu, MF_STRING, ID_FPS_FIXED_165, L"165");
+  AppendMenuW(g_fps_fixed_menu, MF_STRING, ID_FPS_FIXED_240, L"240");
+  AppendMenuW(g_fps_menu, MF_POPUP, reinterpret_cast<UINT_PTR>(g_fps_fixed_menu), L"Fixed");
+  AppendMenuW(g_menu, MF_POPUP, reinterpret_cast<UINT_PTR>(g_fps_menu), L"FPS");
+
   AppendMenuW(g_menu, MF_SEPARATOR, 0, nullptr);
   AppendMenuW(g_menu, MF_STRING, ID_CONFIG, L"Open Config");
   AppendMenuW(g_menu, MF_STRING, ID_LOGS, L"Open Logs");
@@ -144,23 +221,64 @@ bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
   return true;
 }
 
-void update_tray(const TrayState &state) {
-  g_state = state;
-  update_menu();
-}
-
-void shutdown_tray() {
+void shutdown_thread() {
   Shell_NotifyIconW(NIM_DELETE, &g_nid);
   if (g_nid.hIcon) {
     DestroyIcon(g_nid.hIcon);
     g_nid.hIcon = nullptr;
   }
+  if (g_fps_fixed_menu)
+    DestroyMenu(g_fps_fixed_menu);
+  g_fps_fixed_menu = nullptr;
+  if (g_fps_menu)
+    DestroyMenu(g_fps_menu);
+  g_fps_menu = nullptr;
   if (g_menu)
     DestroyMenu(g_menu);
   g_menu = nullptr;
   if (g_hwnd)
     DestroyWindow(g_hwnd);
   g_hwnd = nullptr;
+}
+
+void tray_thread(std::stop_token st, std::promise<bool> ready) {
+  bool ok = init_thread();
+  ready.set_value(ok);
+  if (!ok)
+    return;
+  MSG msg;
+  while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
+  shutdown_thread();
+}
+
+} // namespace
+
+bool init_tray(const TrayState &state, const TrayCallbacks &callbacks) {
+  g_state = state;
+  g_callbacks = callbacks;
+  std::promise<bool> ready;
+  auto fut = ready.get_future();
+  g_thread = std::jthread(tray_thread, std::move(ready));
+  return fut.get();
+}
+
+void update_tray(const TrayState &state) {
+  {
+    std::scoped_lock lock(g_mutex);
+    g_state = state;
+  }
+  if (g_hwnd)
+    PostMessage(g_hwnd, WM_UPDATE, 0, 0);
+}
+
+void shutdown_tray() {
+  if (g_hwnd)
+    PostMessage(g_hwnd, WM_CLOSE, 0, 0);
+  if (g_thread.joinable())
+    g_thread.join();
 }
 
 } // namespace lizard::platform


### PR DESCRIPTION
## Summary
- spawn platform tray in dedicated thread with message loop
- replace "Show FPS" with Auto/Fixed FPS submenu and callbacks
- expose FPS mode controls to overlay and application

## Testing
- `clang-format --dry-run -Werror src/app/main.cpp src/overlay/overlay.cpp src/platform/linux/tray.cpp src/platform/mac/tray.mm src/platform/tray.hpp src/platform/win/tray.cpp`
- `clang-tidy src/app/main.cpp src/overlay/overlay.cpp src/platform/linux/tray.cpp src/platform/mac/tray.mm src/platform/tray.hpp src/platform/win/tray.cpp -- -I.` (fails: KeyboardInterrupt)
- `cmake --preset linux` (fails: downloading OpenGL spec)
- `cmake --build build/linux` (fails: could not load cache)
- `ctest --test-dir build/linux`

------
https://chatgpt.com/codex/tasks/task_e_68a8d19a7f40832591bdc14e8e2815ab