### PR TITLE
Add emoji atlas configuration and dynamic voice count

### DIFF
--- a/src/app/config.h
+++ b/src/app/config.h
@@ -24,8 +24,9 @@ public:
   bool mute() const;
   std::vector<std::string> emoji() const;
   std::unordered_map<std::string, double> emoji_weighted() const;
+  std::vector<std::string> emoji_pngs() const;
   std::optional<std::filesystem::path> sound_path() const;
-  std::optional<std::filesystem::path> emoji_path() const;
+  std::optional<std::filesystem::path> emoji_atlas() const;
   int sound_cooldown_ms() const;
   int max_concurrent_playbacks() const;
   int badges_per_second_max() const;
@@ -64,14 +65,15 @@ private:
   bool enabled_{true};
   bool mute_{false};
   int sound_cooldown_ms_{150};
-  int max_concurrent_playbacks_{4};
+  int max_concurrent_playbacks_{16};
   int badges_per_second_max_{12};
   int badge_min_px_{60};
   int badge_max_px_{108};
   std::vector<std::string> emoji_{"\U0001F98E"};
   std::unordered_map<std::string, double> emoji_weighted_{};
+  std::vector<std::string> emoji_pngs_{};
   std::optional<std::filesystem::path> sound_path_{};
-  std::optional<std::filesystem::path> emoji_path_{};
+  std::optional<std::filesystem::path> emoji_atlas_{};
   bool fullscreen_pause_{true};
   std::vector<std::string> exclude_processes_{};
   bool ignore_injected_{true};

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -53,10 +53,11 @@ int main(int argc, char **argv) {
 
   lizard::audio::Engine engine(static_cast<std::uint32_t>(cfg.max_concurrent_playbacks()),
                                std::chrono::milliseconds(cfg.sound_cooldown_ms()));
-  engine.init(cfg.sound_path(), cfg.volume_percent(), cfg.audio_backend());
+  engine.init(cfg.sound_path(), cfg.volume_percent(), cfg.audio_backend(),
+              static_cast<std::uint32_t>(cfg.max_concurrent_playbacks()));
 
   lizard::overlay::Overlay overlay;
-  overlay.init(cfg, cfg.emoji_path());
+  overlay.init(cfg, cfg.emoji_atlas());
   std::jthread overlay_thread([&](std::stop_token st) { overlay.run(st); });
   std::atomic<bool> fullscreen{false};
   std::jthread fullscreen_thread([&](std::stop_token st) {

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -79,7 +79,7 @@ void Engine::endpoint_callback(ma_context * /*pContext*/, ma_device_type /*devic
   std::lock_guard<std::mutex> lock(self->m_mutex);
   float currentVol = self->m_volume;
   self->shutdown();
-  self->init(self->m_soundPath, self->m_volumePercent, self->m_backend);
+  self->init(self->m_soundPath, self->m_volumePercent, self->m_backend, self->m_maxPlaybacks);
   self->set_volume(currentVol);
 }
 
@@ -89,7 +89,10 @@ Engine::Engine(std::uint32_t maxPlaybacks, std::chrono::milliseconds cooldown)
 Engine::~Engine() { shutdown(); }
 
 bool Engine::init(std::optional<std::filesystem::path> sound_path, int volume_percent,
-                  std::string_view backend) {
+                  std::string_view backend, std::uint32_t maxPlaybacks) {
+  if (maxPlaybacks > 0) {
+    m_maxPlaybacks = maxPlaybacks;
+  }
   m_soundPath = sound_path;
   m_volumePercent = volume_percent;
   m_backend = std::string(backend);

--- a/src/audio/engine.h
+++ b/src/audio/engine.h
@@ -21,11 +21,13 @@ namespace lizard::audio {
 
 class Engine {
 public:
-  Engine(std::uint32_t maxPlaybacks, std::chrono::milliseconds cooldown);
+  Engine(std::uint32_t maxPlaybacks = 16,
+         std::chrono::milliseconds cooldown = std::chrono::milliseconds(150));
   ~Engine();
 
   bool init(std::optional<std::filesystem::path> sound_path = std::nullopt,
-            int volume_percent = 100, std::string_view backend = "miniaudio");
+            int volume_percent = 100, std::string_view backend = "miniaudio",
+            std::uint32_t maxPlaybacks = 0);
   void shutdown();
   void play();
   void set_volume(float vol);


### PR DESCRIPTION
## Summary
- support `emoji_pngs` arrays and `emoji_atlas` path in configuration
- bump `max_concurrent_playbacks` default to 16
- allow audio engine to update voice counts during init

## Testing
- `clang-format --dry-run --Werror src/app/config.h src/app/config.cpp src/app/main.cpp src/audio/engine.h src/audio/engine.cpp src/tests/config_tests.cpp`
- `cmake --preset linux` *(fails: gtk+-3.0 initially missing, installed libgtk-3-dev)*
- `cmake --build build/linux` *(fails: OpenGL functions like glBufferSubData not declared)*
- `clang-tidy src/app/config.cpp src/app/main.cpp src/audio/engine.cpp -p build/linux` *(fails: unknown key 'AnalyzeTemporaryDtors' in spdlog .clang-tidy)*

------
https://chatgpt.com/codex/tasks/task_e_68aa150a3cac8325abd751ac6b10b510