### PR TITLE
Increase default voice limit to 16

### DIFF
--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -8,8 +8,8 @@
   // Minimum milliseconds between sound plays (default: 150)
   "sound_cooldown_ms": 150,
 
-  // Maximum simultaneous sound playbacks (default: 4)
-  "max_concurrent_playbacks": 4,
+  // Maximum simultaneous sound playbacks (default: 16)
+  "max_concurrent_playbacks": 16,
 
   // Limit on badge spawns per second and maximum badges visible at once
   // (oldest badges are dropped when exceeded, default: 12)

--- a/spec.md
+++ b/spec.md
@@ -90,7 +90,7 @@ Most third-party libs are vendored in `third_party/` as source (no dynamic DLLs)
 ## 8) Audio Playback
 
 * **Default**: miniaudio (WASAPI shared), decoded PCM cached in RAM.
-* Low latency play calls; allow overlap (polyphony) up to `max_concurrent_playbacks` (default 4).
+* Low latency play calls; allow overlap (polyphony) up to `max_concurrent_playbacks` (default 16).
 * **Debounce** using `sound_cooldown_ms`.
 * **Volume** 0–100% (default 65%).
 * If device changes, auto-reinit.
@@ -108,7 +108,7 @@ Most third-party libs are vendored in `third_party/` as source (no dynamic DLLs)
   * `enabled` (bool, default true)
   * `mute` (bool, default false)
   * `sound_cooldown_ms` (int, default 150)
-  * `max_concurrent_playbacks` (int, default 4)
+  * `max_concurrent_playbacks` (int, default 16)
   * `badges_per_second_max` (int, default 12)
   * `badge_min_px` / `badge_max_px` (int, default 60/108)
   * `emoji`: array of strings (default `["🦎"]`)

--- a/src/tests/audio_tests.cpp
+++ b/src/tests/audio_tests.cpp
@@ -21,17 +21,17 @@ struct AudioTestAccess {
 using namespace std::chrono_literals;
 
 TEST_CASE("max_concurrent_playbacks respected", "[audio]") {
-  lizard::audio::Engine eng(2, 0ms);
-  AudioTestAccess::voices(eng).resize(2);
+  lizard::audio::Engine eng;
+  AudioTestAccess::voices(eng).resize(16);
 
   g_start_calls = 0;
   g_stop_calls = 0;
 
-  eng.play();
-  eng.play();
-  eng.play();
+  for (int i = 0; i < 17; ++i) {
+    eng.play();
+  }
 
-  REQUIRE(g_start_calls == 3);
+  REQUIRE(g_start_calls == 17);
   REQUIRE(g_stop_calls == 1);
 
   int playing = 0;
@@ -40,7 +40,7 @@ TEST_CASE("max_concurrent_playbacks respected", "[audio]") {
       playing++;
     }
   }
-  REQUIRE(playing == 2);
+  REQUIRE(playing == 16);
 }
 
 TEST_CASE("cooldown prevents rapid retriggers", "[audio]") {


### PR DESCRIPTION
## Summary
- update sample config and spec docs to note 16 concurrent voices
- adjust audio engine test to exercise new default voice limit

## Testing
- `cmake -S . -B build` *(fails: gtk_status_icon deprecated warnings)*
- `cmake --build build` *(fails: gtk_status_icon deprecated warnings)*
- `ctest --test-dir build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3071e3e8832587a76e9be077f302