### PR TITLE
Add configurable FPS controller with refresh-rate probes

### DIFF
--- a/lizard.json.sample
+++ b/lizard.json.sample
@@ -45,6 +45,13 @@
   // Strategy for placing badges ("random_screen" or other future strategies)
   "badge_spawn_strategy": "random_screen",
 
+  // Frame timing: "auto" uses the display refresh rate; "fixed" uses the
+  // `fps_fixed` value below (default: "auto")
+  "fps_mode": "auto",
+
+  // FPS value when using "fixed" mode (default: 60)
+  "fps_fixed": 60,
+
   // Output volume as a percentage (0-100, default: 65)
   "volume_percent": 65,
 


### PR DESCRIPTION
## Summary
- track frame interval with atomic microseconds and compute it from `fps_mode`/`fps_fixed`
- probe platform refresh rate via EnumDisplaySettingsEx, CGDisplayCopyDisplayMode, or XRandR when auto mode is active
- expose `fps_mode` and `fps_fixed` in sample configuration

## Testing
- `clang-format --dry-run src/overlay/overlay.cpp`
- `cmake -S . -B build` *(fails: gtk+-3.0 not found)*
- `clang-tidy src/overlay/overlay.cpp --` *(fails: missing headers without build setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4e7a210c832591d6f9a5f7ddf99b