### PR TITLE
Add global hotkey handling for enable, mute and reload

### DIFF
--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -64,6 +64,14 @@ Config::~Config() {
   cv_.notify_all();
 }
 
+void Config::reload() {
+  std::unique_lock lock(mutex_);
+  load(lock);
+  if (std::filesystem::exists(config_path_)) {
+    last_write_ = std::filesystem::last_write_time(config_path_);
+  }
+}
+
 std::filesystem::path Config::user_config_path() {
 #ifdef _WIN32
   if (auto *local = std::getenv("LOCALAPPDATA")) {

--- a/src/app/config.h
+++ b/src/app/config.h
@@ -46,6 +46,7 @@ public:
   int logging_worker_count() const;
   std::filesystem::path logging_path() const;
 
+  void reload();
   std::condition_variable &reload_cv() { return reload_cv_; }
 
 private:

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -60,41 +60,75 @@ int main(int argc, char **argv) {
   overlay.init(cfg, cfg.emoji_atlas());
   std::jthread overlay_thread([&](std::stop_token st) { overlay.run(st); });
   std::atomic<bool> fullscreen{false};
+  std::atomic<bool> enabled{cfg.enabled()};
+  std::atomic<bool> muted{cfg.mute()};
+  lizard::platform::TrayState tray_state{enabled.load(), muted.load(), cfg.fullscreen_pause(),
+                                         lizard::platform::FpsMode::Auto, 60};
+
+#ifdef _WIN32
+  constexpr int KEY_CTRL_L = 0xA2;
+  constexpr int KEY_CTRL_R = 0xA3;
+  constexpr int KEY_SHIFT_L = 0xA0;
+  constexpr int KEY_SHIFT_R = 0xA1;
+  constexpr int KEY_F9 = 0x78;
+  constexpr int KEY_F10 = 0x79;
+  constexpr int KEY_F11 = 0x7A;
+#elif defined(__APPLE__)
+  constexpr int KEY_CTRL_L = 59;
+  constexpr int KEY_CTRL_R = 62;
+  constexpr int KEY_SHIFT_L = 56;
+  constexpr int KEY_SHIFT_R = 60;
+  constexpr int KEY_F9 = 101;
+  constexpr int KEY_F10 = 109;
+  constexpr int KEY_F11 = 103;
+#else
+  constexpr int KEY_CTRL_L = 37;
+  constexpr int KEY_CTRL_R = 105;
+  constexpr int KEY_SHIFT_L = 50;
+  constexpr int KEY_SHIFT_R = 62;
+  constexpr int KEY_F9 = 75;
+  constexpr int KEY_F10 = 76;
+  constexpr int KEY_F11 = 95;
+#endif
+
+  auto update_state = [&] {
+    bool fs = fullscreen.load();
+    bool paused = (!enabled.load()) || (tray_state.fullscreen_pause && fs);
+    overlay.set_paused(paused);
+    if (paused || muted.load()) {
+      engine.set_volume(0.0f);
+    } else {
+      engine.set_volume(static_cast<float>(cfg.volume_percent()) / 100.0f);
+    }
+  };
+
+  update_state();
   std::jthread fullscreen_thread([&](std::stop_token st) {
     using namespace std::chrono_literals;
-    bool last = false;
     while (!st.stop_requested()) {
-      bool fs = lizard::platform::fullscreen_window_present();
-      fullscreen = fs;
-      bool paused = cfg.fullscreen_pause() && fs;
-      overlay.set_paused(paused);
-      if (paused != last) {
-        if (paused) {
-          engine.set_volume(0.0f);
-        } else {
-          engine.set_volume(cfg.mute() ? 0.0f
-                                      : static_cast<float>(cfg.volume_percent()) / 100.0f);
-        }
-        last = paused;
-      }
+      fullscreen = lizard::platform::fullscreen_window_present();
+      update_state();
       std::this_thread::sleep_for(500ms);
     }
   });
 
   std::atomic<bool> running{true};
-  lizard::platform::TrayState tray_state{cfg.enabled(), cfg.mute(), cfg.fullscreen_pause(),
-                                         lizard::platform::FpsMode::Auto, 60};
   lizard::platform::TrayCallbacks tray_callbacks{
       [&](bool v) {
+        enabled = v;
         tray_state.enabled = v;
+        update_state();
         lizard::platform::update_tray(tray_state);
       },
       [&](bool v) {
+        muted = v;
         tray_state.muted = v;
+        update_state();
         lizard::platform::update_tray(tray_state);
       },
       [&](bool v) {
         tray_state.fullscreen_pause = v;
+        update_state();
         lizard::platform::update_tray(tray_state);
       },
       [&](lizard::platform::FpsMode m) {
@@ -114,12 +148,41 @@ int main(int argc, char **argv) {
       [&]() { running = false; }};
   lizard::platform::init_tray(tray_state, tray_callbacks);
 
+  bool ctrl_down = false;
+  bool shift_down = false;
   auto hook = hook::KeyboardHook::create(
-      [&](int /*key*/, bool pressed) {
-        if (pressed && cfg.enabled()) {
+      [&](int key, bool pressed) {
+        if (key == KEY_CTRL_L || key == KEY_CTRL_R) {
+          ctrl_down = pressed;
+        } else if (key == KEY_SHIFT_L || key == KEY_SHIFT_R) {
+          shift_down = pressed;
+        }
+
+        if (pressed && ctrl_down && shift_down) {
+          if (key == KEY_F9) {
+            enabled = !enabled.load();
+            tray_state.enabled = enabled.load();
+            update_state();
+            lizard::platform::update_tray(tray_state);
+            return;
+          }
+          if (key == KEY_F10) {
+            muted = !muted.load();
+            tray_state.muted = muted.load();
+            update_state();
+            lizard::platform::update_tray(tray_state);
+            return;
+          }
+          if (key == KEY_F11) {
+            cfg.reload_cv().notify_all();
+            return;
+          }
+        }
+
+        if (pressed && enabled.load()) {
           bool paused = cfg.fullscreen_pause() && fullscreen.load();
           if (!paused) {
-            if (!cfg.mute()) {
+            if (!muted.load()) {
               engine.play();
             }
             overlay.spawn_badge(0, 0.5f, 0.5f);
@@ -142,7 +205,10 @@ int main(int argc, char **argv) {
       tray_state.enabled = cfg.enabled();
       tray_state.muted = cfg.mute();
       tray_state.fullscreen_pause = cfg.fullscreen_pause();
+      enabled = tray_state.enabled;
+      muted = tray_state.muted;
       lizard::platform::update_tray(tray_state);
+      update_state();
     }
   });
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -199,6 +199,7 @@ int main(int argc, char **argv) {
           } else if (ctrl_down && shift_down) {
             if (!f11_down) {
               f11_down = true;
+              cfg.reload();
               cfg.reload_cv().notify_all();
             }
             f11_down = true;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -164,40 +164,46 @@ int main(int argc, char **argv) {
         } else if (key == KEY_F9) {
           if (!pressed) {
             f9_down = false;
-          } else {
-            if (!f9_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f9_down) {
               f9_down = true;
               enabled = !enabled.load();
               tray_state.enabled = enabled.load();
               update_state();
               lizard::platform::update_tray(tray_state);
-              return;
             }
+            f9_down = true;
+            return;
+          } else {
             f9_down = true;
           }
         } else if (key == KEY_F10) {
           if (!pressed) {
             f10_down = false;
-          } else {
-            if (!f10_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f10_down) {
               f10_down = true;
               muted = !muted.load();
               tray_state.muted = muted.load();
               update_state();
               lizard::platform::update_tray(tray_state);
-              return;
             }
+            f10_down = true;
+            return;
+          } else {
             f10_down = true;
           }
         } else if (key == KEY_F11) {
           if (!pressed) {
             f11_down = false;
-          } else {
-            if (!f11_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f11_down) {
               f11_down = true;
               cfg.reload_cv().notify_all();
-              return;
             }
+            f11_down = true;
+            return;
+          } else {
             f11_down = true;
           }
         }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -152,32 +152,53 @@ int main(int argc, char **argv) {
 
   bool ctrl_down = false;
   bool shift_down = false;
+  bool f9_down = false;
+  bool f10_down = false;
+  bool f11_down = false;
   auto hook = hook::KeyboardHook::create(
       [&](int key, bool pressed) {
         if (key == KEY_CTRL_L || key == KEY_CTRL_R) {
           ctrl_down = pressed;
         } else if (key == KEY_SHIFT_L || key == KEY_SHIFT_R) {
           shift_down = pressed;
-        }
-
-        if (pressed && ctrl_down && shift_down) {
-          if (key == KEY_F9) {
-            enabled = !enabled.load();
-            tray_state.enabled = enabled.load();
-            update_state();
-            lizard::platform::update_tray(tray_state);
-            return;
+        } else if (key == KEY_F9) {
+          if (!pressed) {
+            f9_down = false;
+          } else {
+            if (!f9_down && ctrl_down && shift_down) {
+              f9_down = true;
+              enabled = !enabled.load();
+              tray_state.enabled = enabled.load();
+              update_state();
+              lizard::platform::update_tray(tray_state);
+              return;
+            }
+            f9_down = true;
           }
-          if (key == KEY_F10) {
-            muted = !muted.load();
-            tray_state.muted = muted.load();
-            update_state();
-            lizard::platform::update_tray(tray_state);
-            return;
+        } else if (key == KEY_F10) {
+          if (!pressed) {
+            f10_down = false;
+          } else {
+            if (!f10_down && ctrl_down && shift_down) {
+              f10_down = true;
+              muted = !muted.load();
+              tray_state.muted = muted.load();
+              update_state();
+              lizard::platform::update_tray(tray_state);
+              return;
+            }
+            f10_down = true;
           }
-          if (key == KEY_F11) {
-            cfg.reload_cv().notify_all();
-            return;
+        } else if (key == KEY_F11) {
+          if (!pressed) {
+            f11_down = false;
+          } else {
+            if (!f11_down && ctrl_down && shift_down) {
+              f11_down = true;
+              cfg.reload_cv().notify_all();
+              return;
+            }
+            f11_down = true;
           }
         }
 

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -220,6 +220,7 @@ void Engine::play() {
 }
 
 void Engine::set_volume(float vol) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_volume = std::clamp(vol, 0.0f, 1.0f);
   m_volumePercent = static_cast<int>(m_volume * 100.0f);
   for (auto &voice : m_voices) {

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -175,7 +175,7 @@ bool Engine::init(std::optional<std::filesystem::path> sound_path, int volume_pe
     ma_sound_init_from_data_source(&m_engine, &m_buffer, 0, nullptr, &voice.sound);
   }
   int clampedPercent = std::clamp(volume_percent, 0, 100);
-  set_volume(static_cast<float>(clampedPercent) / 100.0f);
+  set_volume_locked(static_cast<float>(clampedPercent) / 100.0f);
   return true;
 }
 

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -85,7 +85,7 @@ void Engine::endpoint_callback(ma_context *, ma_device_type deviceType,
   float currentVol = self->m_volume;
   self->shutdown();
   self->init(self->m_soundPath, self->m_volumePercent, self->m_backend, self->m_maxPlaybacks);
-  self->set_volume(currentVol);
+  self->set_volume_locked(currentVol);
 }
 
 Engine::Engine(std::uint32_t maxPlaybacks, std::chrono::milliseconds cooldown)
@@ -221,6 +221,10 @@ void Engine::play() {
 
 void Engine::set_volume(float vol) {
   std::lock_guard<std::mutex> lock(m_mutex);
+  set_volume_locked(vol);
+}
+
+void Engine::set_volume_locked(float vol) {
   m_volume = std::clamp(vol, 0.0f, 1.0f);
   m_volumePercent = static_cast<int>(m_volume * 100.0f);
   for (auto &voice : m_voices) {

--- a/src/audio/engine.h
+++ b/src/audio/engine.h
@@ -33,6 +33,8 @@ public:
   void set_volume(float vol);
 
 private:
+  void set_volume_locked(float vol);
+
   struct Voice {
     ma_sound sound{};
     std::chrono::steady_clock::time_point start{};

--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -1,3 +1,19 @@
+// glad must be included before any platform window headers to ensure modern
+// OpenGL symbols like glBindBuffer are declared. Even in test builds we include
+// it so GL types are available.
+#include "glad/glad.h"
+#ifndef LIZARD_TEST
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+#else
+extern "C" {
+unsigned char *stbi_load(const char *, int *, int *, int *, int);
+unsigned char *stbi_load_from_memory(const unsigned char *, int, int *, int *, int *, int);
+const char *stbi_failure_reason(void);
+void stbi_image_free(void *);
+}
+#endif
+
 #include "platform/window.hpp"
 #include "platform/tray.hpp"
 
@@ -24,19 +40,6 @@
 #include <X11/extensions/Xrandr.h>
 #elif defined(__APPLE__)
 #include <CoreGraphics/CoreGraphics.h>
-#endif
-
-#ifndef LIZARD_TEST
-#include "glad/glad.h"
-#define STB_IMAGE_IMPLEMENTATION
-#include "stb_image.h"
-#else
-extern "C" {
-unsigned char *stbi_load(const char *, int *, int *, int *, int);
-unsigned char *stbi_load_from_memory(const unsigned char *, int, int *, int *, int *, int);
-const char *stbi_failure_reason(void);
-void stbi_image_free(void *);
-}
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
## Summary
- Track modifier keys in keyboard hook and detect Ctrl+Shift+F9/F10/F11
- Toggle enable/mute states and refresh configuration in response to hotkeys
- Sync tray, audio engine and overlay state when these shortcuts fire

## Testing
- `clang-format --dry-run --Werror src/app/main.cpp`
- `cmake --preset linux` *(fails: libvorbisfile not found / build dependencies missing?)*
- `cmake --build build/linux` *(fails: OpenGL functions like glBindBuffer not declared)*


------
https://chatgpt.com/codex/tasks/task_e_68bc423ab39483259c3931b59fc4bff1