### PR TITLE
Add global hotkey handling for enable, mute and reload

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -164,40 +164,46 @@ int main(int argc, char **argv) {
         } else if (key == KEY_F9) {
           if (!pressed) {
             f9_down = false;
-          } else {
-            if (!f9_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f9_down) {
               f9_down = true;
               enabled = !enabled.load();
               tray_state.enabled = enabled.load();
               update_state();
               lizard::platform::update_tray(tray_state);
-              return;
             }
+            f9_down = true;
+            return;
+          } else {
             f9_down = true;
           }
         } else if (key == KEY_F10) {
           if (!pressed) {
             f10_down = false;
-          } else {
-            if (!f10_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f10_down) {
               f10_down = true;
               muted = !muted.load();
               tray_state.muted = muted.load();
               update_state();
               lizard::platform::update_tray(tray_state);
-              return;
             }
+            f10_down = true;
+            return;
+          } else {
             f10_down = true;
           }
         } else if (key == KEY_F11) {
           if (!pressed) {
             f11_down = false;
-          } else {
-            if (!f11_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f11_down) {
               f11_down = true;
               cfg.reload_cv().notify_all();
-              return;
             }
+            f11_down = true;
+            return;
+          } else {
             f11_down = true;
           }
         }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -152,32 +152,53 @@ int main(int argc, char **argv) {
 
   bool ctrl_down = false;
   bool shift_down = false;
+  bool f9_down = false;
+  bool f10_down = false;
+  bool f11_down = false;
   auto hook = hook::KeyboardHook::create(
       [&](int key, bool pressed) {
         if (key == KEY_CTRL_L || key == KEY_CTRL_R) {
           ctrl_down = pressed;
         } else if (key == KEY_SHIFT_L || key == KEY_SHIFT_R) {
           shift_down = pressed;
-        }
-
-        if (pressed && ctrl_down && shift_down) {
-          if (key == KEY_F9) {
-            enabled = !enabled.load();
-            tray_state.enabled = enabled.load();
-            update_state();
-            lizard::platform::update_tray(tray_state);
-            return;
+        } else if (key == KEY_F9) {
+          if (!pressed) {
+            f9_down = false;
+          } else {
+            if (!f9_down && ctrl_down && shift_down) {
+              f9_down = true;
+              enabled = !enabled.load();
+              tray_state.enabled = enabled.load();
+              update_state();
+              lizard::platform::update_tray(tray_state);
+              return;
+            }
+            f9_down = true;
           }
-          if (key == KEY_F10) {
-            muted = !muted.load();
-            tray_state.muted = muted.load();
-            update_state();
-            lizard::platform::update_tray(tray_state);
-            return;
+        } else if (key == KEY_F10) {
+          if (!pressed) {
+            f10_down = false;
+          } else {
+            if (!f10_down && ctrl_down && shift_down) {
+              f10_down = true;
+              muted = !muted.load();
+              tray_state.muted = muted.load();
+              update_state();
+              lizard::platform::update_tray(tray_state);
+              return;
+            }
+            f10_down = true;
           }
-          if (key == KEY_F11) {
-            cfg.reload_cv().notify_all();
-            return;
+        } else if (key == KEY_F11) {
+          if (!pressed) {
+            f11_down = false;
+          } else {
+            if (!f11_down && ctrl_down && shift_down) {
+              f11_down = true;
+              cfg.reload_cv().notify_all();
+              return;
+            }
+            f11_down = true;
           }
         }
 

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -220,6 +220,7 @@ void Engine::play() {
 }
 
 void Engine::set_volume(float vol) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_volume = std::clamp(vol, 0.0f, 1.0f);
   m_volumePercent = static_cast<int>(m_volume * 100.0f);
   for (auto &voice : m_voices) {

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -175,7 +175,7 @@ bool Engine::init(std::optional<std::filesystem::path> sound_path, int volume_pe
     ma_sound_init_from_data_source(&m_engine, &m_buffer, 0, nullptr, &voice.sound);
   }
   int clampedPercent = std::clamp(volume_percent, 0, 100);
-  set_volume(static_cast<float>(clampedPercent) / 100.0f);
+  set_volume_locked(static_cast<float>(clampedPercent) / 100.0f);
   return true;
 }
 

--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -85,7 +85,7 @@ void Engine::endpoint_callback(ma_context *, ma_device_type deviceType,
   float currentVol = self->m_volume;
   self->shutdown();
   self->init(self->m_soundPath, self->m_volumePercent, self->m_backend, self->m_maxPlaybacks);
-  self->set_volume(currentVol);
+  self->set_volume_locked(currentVol);
 }
 
 Engine::Engine(std::uint32_t maxPlaybacks, std::chrono::milliseconds cooldown)
@@ -221,6 +221,10 @@ void Engine::play() {
 
 void Engine::set_volume(float vol) {
   std::lock_guard<std::mutex> lock(m_mutex);
+  set_volume_locked(vol);
+}
+
+void Engine::set_volume_locked(float vol) {
   m_volume = std::clamp(vol, 0.0f, 1.0f);
   m_volumePercent = static_cast<int>(m_volume * 100.0f);
   for (auto &voice : m_voices) {

--- a/src/audio/engine.h
+++ b/src/audio/engine.h
@@ -33,6 +33,8 @@ public:
   void set_volume(float vol);
 
 private:
+  void set_volume_locked(float vol);
+
   struct Voice {
     ma_sound sound{};
     std::chrono::steady_clock::time_point start{};


### PR DESCRIPTION
## Summary
- Track function key state to debounce hotkey toggles and avoid auto-repeat flip-flopping
- Guard Engine::set_volume with a mutex to serialize volume updates across threads

## Testing
- `clang-format --dry-run --Werror src/app/main.cpp src/audio/engine.cpp`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux` *(fails: build.ninja: No such file or directory)*
- `clang-tidy -p build/linux src/app/main.cpp src/audio/engine.cpp` *(compilation database missing / incomplete types)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9879fdc48325a17bc92d3cd7cc9c