### PR TITLE
Add global hotkey handling for enable, mute and reload

### DIFF
--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -85,7 +85,7 @@ void Engine::endpoint_callback(ma_context *, ma_device_type deviceType,
   float currentVol = self->m_volume;
   self->shutdown();
   self->init(self->m_soundPath, self->m_volumePercent, self->m_backend, self->m_maxPlaybacks);
-  self->set_volume(currentVol);
+  self->set_volume_locked(currentVol);
 }
 
 Engine::Engine(std::uint32_t maxPlaybacks, std::chrono::milliseconds cooldown)
@@ -221,6 +221,10 @@ void Engine::play() {
 
 void Engine::set_volume(float vol) {
   std::lock_guard<std::mutex> lock(m_mutex);
+  set_volume_locked(vol);
+}
+
+void Engine::set_volume_locked(float vol) {
   m_volume = std::clamp(vol, 0.0f, 1.0f);
   m_volumePercent = static_cast<int>(m_volume * 100.0f);
   for (auto &voice : m_voices) {

--- a/src/audio/engine.h
+++ b/src/audio/engine.h
@@ -33,6 +33,8 @@ public:
   void set_volume(float vol);
 
 private:
+  void set_volume_locked(float vol);
+
   struct Voice {
     ma_sound sound{};
     std::chrono::steady_clock::time_point start{};


### PR DESCRIPTION
## Summary
- Track function key state to debounce hotkey toggles and avoid auto-repeat flip-flopping
- Guard Engine::set_volume with a mutex to serialize volume updates across threads
- Prevent recursive set_volume lock during device change by using a lock-free helper when the caller already holds the mutex

## Testing
- `clang-format --dry-run --Werror src/app/main.cpp src/audio/engine.cpp src/audio/engine.h`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux` *(fails: build.ninja: No such file or directory)*
- `clang-tidy -p build/linux src/app/main.cpp src/audio/engine.cpp src/audio/engine.h` *(compilation database missing / incomplete types)*

------
https://chatgpt.com/codex/tasks/task_e_68bca1cc61248325b861b7901e148413