### PR TITLE
Add global hotkey handling for enable, mute and reload

### DIFF
--- a/src/audio/engine.cpp
+++ b/src/audio/engine.cpp
@@ -175,7 +175,7 @@ bool Engine::init(std::optional<std::filesystem::path> sound_path, int volume_pe
     ma_sound_init_from_data_source(&m_engine, &m_buffer, 0, nullptr, &voice.sound);
   }
   int clampedPercent = std::clamp(volume_percent, 0, 100);
-  set_volume(static_cast<float>(clampedPercent) / 100.0f);
+  set_volume_locked(static_cast<float>(clampedPercent) / 100.0f);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Track function key state to debounce hotkey toggles and avoid auto-repeat flip-flopping
- Guard Engine::set_volume with a mutex to serialize volume updates across threads
- Avoid recursive volume-locking during engine init when device callbacks reinitialize audio

## Testing
- `clang-format --dry-run --Werror src/app/main.cpp src/audio/engine.cpp src/audio/engine.h`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux` *(fails: build.ninja: No such file or directory)*
- `clang-tidy -p build/linux src/app/main.cpp src/audio/engine.cpp src/audio/engine.h` *(missing headers / numerous warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bca98670688325a347fe7f3a60e70f