### PR TITLE
Add global hotkey handling for enable, mute and reload

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -164,40 +164,46 @@ int main(int argc, char **argv) {
         } else if (key == KEY_F9) {
           if (!pressed) {
             f9_down = false;
-          } else {
-            if (!f9_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f9_down) {
               f9_down = true;
               enabled = !enabled.load();
               tray_state.enabled = enabled.load();
               update_state();
               lizard::platform::update_tray(tray_state);
-              return;
             }
+            f9_down = true;
+            return;
+          } else {
             f9_down = true;
           }
         } else if (key == KEY_F10) {
           if (!pressed) {
             f10_down = false;
-          } else {
-            if (!f10_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f10_down) {
               f10_down = true;
               muted = !muted.load();
               tray_state.muted = muted.load();
               update_state();
               lizard::platform::update_tray(tray_state);
-              return;
             }
+            f10_down = true;
+            return;
+          } else {
             f10_down = true;
           }
         } else if (key == KEY_F11) {
           if (!pressed) {
             f11_down = false;
-          } else {
-            if (!f11_down && ctrl_down && shift_down) {
+          } else if (ctrl_down && shift_down) {
+            if (!f11_down) {
               f11_down = true;
               cfg.reload_cv().notify_all();
-              return;
             }
+            f11_down = true;
+            return;
+          } else {
             f11_down = true;
           }
         }


### PR DESCRIPTION
## Summary
- Track function key state to debounce hotkey toggles and avoid auto-repeat flip-flopping
- Guard Engine::set_volume with a mutex to serialize volume updates across threads
- Return early on repeated hotkey presses with modifiers to suppress unintended overlay/audio spam

## Testing
- `clang-format --dry-run --Werror src/app/main.cpp src/audio/engine.cpp src/audio/engine.h`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux` *(fails: build.ninja: No such file or directory)*
- `clang-tidy -p build/linux src/app/main.cpp src/audio/engine.cpp src/audio/engine.h` *(compilation database missing / header errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcadcfdba4832588dcece33676ea3a