### PR TITLE
Trigger synchronous config reload on hotkey

### DIFF
--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -64,6 +64,14 @@ Config::~Config() {
   cv_.notify_all();
 }
 
+void Config::reload() {
+  std::unique_lock lock(mutex_);
+  load(lock);
+  if (std::filesystem::exists(config_path_)) {
+    last_write_ = std::filesystem::last_write_time(config_path_);
+  }
+}
+
 std::filesystem::path Config::user_config_path() {
 #ifdef _WIN32
   if (auto *local = std::getenv("LOCALAPPDATA")) {

--- a/src/app/config.h
+++ b/src/app/config.h
@@ -46,6 +46,7 @@ public:
   int logging_worker_count() const;
   std::filesystem::path logging_path() const;
 
+  void reload();
   std::condition_variable &reload_cv() { return reload_cv_; }
 
 private:

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -199,6 +199,7 @@ int main(int argc, char **argv) {
           } else if (ctrl_down && shift_down) {
             if (!f11_down) {
               f11_down = true;
+              cfg.reload();
               cfg.reload_cv().notify_all();
             }
             f11_down = true;


### PR DESCRIPTION
## Summary
- expose `Config::reload` for immediate config parsing
- invoke `cfg.reload()` before notifying reload thread when Ctrl+Shift+F11 is pressed

## Testing
- `clang-format --dry-run --Werror src/app/config.h src/app/config.cpp src/app/main.cpp`
- `cmake --preset linux` *(fails: Package 'gtk+-3.0' not found)*
- `cmake --build build/linux` *(fails: build.ninja: No such file or directory)*
- `clang-tidy -p build/linux src/app/main.cpp src/app/config.cpp src/app/config.h` *(missing compilation database, many warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb771d07083259db94411f389aa6e