### PR TITLE
Add cursor-follow badge spawning

### DIFF
--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -167,6 +167,7 @@ void Overlay::update_frame_interval() {
       CGDisplayModeRelease(mode);
     }
 #elif defined(__linux__)
+    platform::init_xlib_threads();
     Display *dpy = XOpenDisplay(nullptr);
     if (dpy) {
       Window root = DefaultRootWindow(dpy);
@@ -342,6 +343,7 @@ bool Overlay::init(const app::Config &cfg, std::optional<std::filesystem::path> 
     desc.height = 600;
   }
 #elif defined(__linux__)
+  platform::init_xlib_threads();
   if (Display *dpy = XOpenDisplay(nullptr)) {
     int screen = DefaultScreen(dpy);
     desc.x = 0;

--- a/src/platform/linux/window.cpp
+++ b/src/platform/linux/window.cpp
@@ -7,6 +7,7 @@
 #include <X11/extensions/shape.h>
 #include <X11/extensions/Xrandr.h>
 #include <vector>
+#include <mutex>
 
 namespace lizard::platform {
 
@@ -15,6 +16,8 @@ namespace {
 Display *g_display = nullptr;
 ::Window g_root = 0;
 ::Window g_overlay = 0;
+std::mutex g_display_mutex;
+std::once_flag g_xlib_init_once;
 
 float compute_dpi(Display *dpy) {
   int screen = DefaultScreen(dpy);
@@ -27,7 +30,9 @@ float compute_dpi(Display *dpy) {
 } // namespace
 
 Window create_overlay_window(const WindowDesc &desc) {
+  std::call_once(g_xlib_init_once, []() { XInitThreads(); });
   Window result{};
+  std::lock_guard<std::mutex> lock(g_display_mutex);
   g_display = XOpenDisplay(nullptr);
   if (!g_display) {
     return result;
@@ -98,6 +103,7 @@ Window create_overlay_window(const WindowDesc &desc) {
 }
 
 void destroy_window(Window &window) {
+  std::lock_guard<std::mutex> lock(g_display_mutex);
   if (g_display && window.native) {
     glXMakeCurrent(g_display, None, nullptr);
     if (window.glContext) {
@@ -112,6 +118,7 @@ void destroy_window(Window &window) {
 }
 
 void poll_events(Window &window) {
+  std::lock_guard<std::mutex> lock(g_display_mutex);
   if (!g_display || !window.native) {
     return;
   }
@@ -122,6 +129,7 @@ void poll_events(Window &window) {
 }
 
 std::pair<float, float> cursor_pos() {
+  std::lock_guard<std::mutex> lock(g_display_mutex);
   if (!g_display) {
     return {0.5f, 0.5f};
   }
@@ -142,6 +150,7 @@ std::pair<float, float> cursor_pos() {
 }
 
 bool fullscreen_window_present() {
+  std::lock_guard<std::mutex> lock(g_display_mutex);
   if (!g_display) {
     return false;
   }

--- a/src/platform/linux/window.cpp
+++ b/src/platform/linux/window.cpp
@@ -29,8 +29,12 @@ float compute_dpi(Display *dpy) {
 
 } // namespace
 
-Window create_overlay_window(const WindowDesc &desc) {
+void init_xlib_threads() {
   std::call_once(g_xlib_init_once, []() { XInitThreads(); });
+}
+
+Window create_overlay_window(const WindowDesc &desc) {
+  init_xlib_threads();
   Window result{};
   std::lock_guard<std::mutex> lock(g_display_mutex);
   g_display = XOpenDisplay(nullptr);

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -38,5 +38,8 @@ void destroy_window(Window &window);
 void poll_events(Window &window);
 bool fullscreen_window_present();
 std::pair<float, float> cursor_pos();
+#if defined(__linux__)
+void init_xlib_threads();
+#endif
 
 } // namespace lizard::platform


### PR DESCRIPTION
## Summary
- allow overlay to spawn a badge without specifying a sprite, using weighted selection
- fetch normalized cursor position from platform backends
- use cursor position in main hook when strategy is cursor_follow
- guard Xlib display access with a mutex and initialize Xlib thread support on Linux

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux --target overlay_tests` *(fails: loading 'build.ninja': No such file or directory)*
- `cd build/linux && ctest -R overlay_select --output-on-failure` *(fails: No tests were found!!!)*
- `clang-tidy src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm -p build/linux` *(fails: 'cxxopts.hpp' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf25e846f083259898209f9f89c904