### PR TITLE
Add cursor-follow badge spawning

### DIFF
--- a/src/overlay/overlay.cpp
+++ b/src/overlay/overlay.cpp
@@ -167,6 +167,7 @@ void Overlay::update_frame_interval() {
       CGDisplayModeRelease(mode);
     }
 #elif defined(__linux__)
+    platform::init_xlib_threads();
     Display *dpy = XOpenDisplay(nullptr);
     if (dpy) {
       Window root = DefaultRootWindow(dpy);
@@ -342,6 +343,7 @@ bool Overlay::init(const app::Config &cfg, std::optional<std::filesystem::path> 
     desc.height = 600;
   }
 #elif defined(__linux__)
+  platform::init_xlib_threads();
   if (Display *dpy = XOpenDisplay(nullptr)) {
     int screen = DefaultScreen(dpy);
     desc.x = 0;

--- a/src/platform/linux/window.cpp
+++ b/src/platform/linux/window.cpp
@@ -29,8 +29,12 @@ float compute_dpi(Display *dpy) {
 
 } // namespace
 
-Window create_overlay_window(const WindowDesc &desc) {
+void init_xlib_threads() {
   std::call_once(g_xlib_init_once, []() { XInitThreads(); });
+}
+
+Window create_overlay_window(const WindowDesc &desc) {
+  init_xlib_threads();
   Window result{};
   std::lock_guard<std::mutex> lock(g_display_mutex);
   g_display = XOpenDisplay(nullptr);

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -38,5 +38,8 @@ void destroy_window(Window &window);
 void poll_events(Window &window);
 bool fullscreen_window_present();
 std::pair<float, float> cursor_pos();
+#if defined(__linux__)
+void init_xlib_threads();
+#endif
 
 } // namespace lizard::platform


### PR DESCRIPTION
## Summary
- ensure XInitThreads runs before any Xlib call on Linux
- expose init helper and use it in early overlay code paths

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux --target overlay_tests` *(fails: loading 'build.ninja': No such file or directory)*
- `cd build/linux && ctest -R overlay_select --output-on-failure` *(fails: No tests were found!!!)*
- `clang-tidy src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm -p build/linux` *(fails: 'cxxopts.hpp' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf27ff82e4832589f297f3107bcdd4