### PR TITLE
Fix tray config path and normalize mac cursor position

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -152,7 +152,7 @@ int main(int argc, char **argv) {
         lizard::platform::update_tray(tray_state);
       },
       [&]() {
-        auto path = cfg.logging_path().parent_path() / "lizard.json";
+        auto path = cfg.user_config_path();
         if (!std::filesystem::exists(path)) {
           path = cfg.logging_path().parent_path() / "lizard.json";
         }

--- a/src/platform/mac/window.mm
+++ b/src/platform/mac/window.mm
@@ -83,10 +83,19 @@ void poll_events(Window &window) {
 std::pair<float, float> cursor_pos() {
   @autoreleasepool {
     CGPoint p = [NSEvent mouseLocation];
-    NSScreen *s = [NSScreen mainScreen];
-    NSRect frame = [s frame];
-    float x = (p.x - frame.origin.x) / frame.size.width;
-    float y = (p.y - frame.origin.y) / frame.size.height;
+    CGFloat min_x = CGFLOAT_MAX;
+    CGFloat min_y = CGFLOAT_MAX;
+    CGFloat max_x = -CGFLOAT_MAX;
+    CGFloat max_y = -CGFLOAT_MAX;
+    for (NSScreen *s in [NSScreen screens]) {
+      NSRect frame = [s frame];
+      min_x = std::min(min_x, frame.origin.x);
+      min_y = std::min(min_y, frame.origin.y);
+      max_x = std::max(max_x, frame.origin.x + frame.size.width);
+      max_y = std::max(max_y, frame.origin.y + frame.size.height);
+    }
+    float x = (p.x - min_x) / (max_x - min_x);
+    float y = (p.y - min_y) / (max_y - min_y);
     return {x, y};
   }
 }


### PR DESCRIPTION
## Summary
- prefer `user_config_path` for tray "Open Config" with fallback to log directory
- normalize macOS cursor position across multiple monitors

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux --target overlay_tests` *(fails: no build.ninja)*
- `cd build/linux && ctest -R overlay_select --output-on-failure` *(no tests found)*
- `clang-tidy src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm -p build/linux` *(fails: missing compilation database and headers)*

------
https://chatgpt.com/codex/tasks/task_e_68c072f7ad7c8325b1a448e9c7e83de1