### PR TITLE
Add cursor-follow badge spawning

### DIFF
--- a/src/platform/mac/window.mm
+++ b/src/platform/mac/window.mm
@@ -94,8 +94,12 @@ std::pair<float, float> cursor_pos() {
       max_x = std::max(max_x, frame.origin.x + frame.size.width);
       max_y = std::max(max_y, frame.origin.y + frame.size.height);
     }
-    float x = (p.x - min_x) / (max_x - min_x);
-    float y = (p.y - min_y) / (max_y - min_y);
+    float w = max_x - min_x;
+    float h = max_y - min_y;
+    float x = w > 0.0f ? static_cast<float>((p.x - min_x) / w) : 0.0f;
+    float y = h > 0.0f ? static_cast<float>((max_y - p.y) / h) : 0.0f;
+    x = std::clamp(x, 0.0f, 1.0f);
+    y = std::clamp(y, 0.0f, 1.0f);
     return {x, y};
   }
 }


### PR DESCRIPTION
## Summary
- allow overlay to spawn a badge without specifying a sprite, using weighted selection
- fetch normalized cursor position from platform backends
- use cursor position in main hook when strategy is cursor_follow
- ensure macOS cursor positions account for all monitors and clamp within bounds

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux --target overlay_tests` *(fails: build.ninja missing)*
- `cd build/linux && ctest -R overlay_select --output-on-failure` *(no tests found)*
- `clang-tidy src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm -p build/linux` *(fails: compilation database missing and headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1adc58b4483258b53e4c079b63488