### PR TITLE
Add Linux platform stubs for overlay tests

### DIFF
--- a/src/tests/overlay_tests.cpp
+++ b/src/tests/overlay_tests.cpp
@@ -29,6 +29,13 @@ void glDeleteProgram(GLuint);
 #include "overlay/gl_raii.cpp"
 #include "overlay/overlay.cpp"
 
+#if defined(__linux__)
+namespace lizard::platform {
+void init_xlib_threads() {}
+std::pair<float, float> cursor_pos() { return {0.0f, 0.0f}; }
+} // namespace lizard::platform
+#endif
+
 struct OverlayTestAccess {
   static std::vector<lizard::overlay::Sprite> &sprites(lizard::overlay::Overlay &o) {
     return o.m_sprites;


### PR DESCRIPTION
## Summary
- stub `init_xlib_threads` and `cursor_pos` for Linux in overlay unit tests to satisfy linker

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/tests/overlay_tests.cpp`
- `cmake --preset linux`
- `cmake --build build/linux --target overlay_tests`
- `cd build/linux && ctest -R overlay_select --output-on-failure` *(fails: segmentation fault)*
- `clang-tidy src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/tests/overlay_tests.cpp -p build/linux --config="{}"` *(fails: compiler errors and config issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c1be4fde5483259c1b92fd126002d9