### PR TITLE
Add cursor-follow badge spawning

### DIFF
--- a/src/platform/win/window.cpp
+++ b/src/platform/win/window.cpp
@@ -113,7 +113,6 @@ std::pair<float, float> cursor_pos() {
   if (vw > 0 && vh > 0) {
     x = static_cast<float>(p.x - vx) / static_cast<float>(vw);
     y = static_cast<float>(p.y - vy) / static_cast<float>(vh);
-    y = 1.0f - y;
   }
   x = std::clamp(x, 0.0f, 1.0f);
   y = std::clamp(y, 0.0f, 1.0f);


### PR DESCRIPTION
## Summary
- remove Y-axis inversion from Windows cursor normalization to match other platforms

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/tests/overlay_tests.cpp`
- `cmake --preset linux`
- `cmake --build build/linux --target overlay_tests`
- `cd build/linux && ctest -R overlay_select --output-on-failure` *(fails: segmentation fault)*
- `clang-tidy src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/tests/overlay_tests.cpp -p build/linux --config="{}"` *(fails: no compilation database, OpenGL headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a01142108325ad850bf778a67e09