### PR TITLE
Add cursor-follow badge spawning

### DIFF
--- a/src/platform/linux/window.cpp
+++ b/src/platform/linux/window.cpp
@@ -174,7 +174,7 @@ std::pair<float, float> cursor_pos() {
   float x = w > 0.0f ? static_cast<float>(root_x - min_x) / w : 0.5f;
   float y = h > 0.0f ? static_cast<float>(root_y - min_y) / h : 0.5f;
   x = std::clamp(x, 0.0f, 1.0f);
-  y = 1.0f - std::clamp(y, 0.0f, 1.0f);
+  y = std::clamp(y, 0.0f, 1.0f);
   return {x, y};
 }
 


### PR DESCRIPTION
## Summary
- Clamp Linux cursor coordinates to the combined bounds of all monitors and flip the Y axis so cursor-follow badges stay on-screen

## Testing
- `clang-format --dry-run -Werror src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/tests/overlay_tests.cpp`
- `cmake --preset linux` *(fails: gtk+-3.0 not found)*
- `cmake --build build/linux --target overlay_tests` *(fails: build.ninja missing)*
- `cd build/linux && ctest -R overlay_select --output-on-failure` *(fails: no tests were found)*
- `clang-tidy src/overlay/overlay.cpp src/app/main.cpp src/platform/window.hpp src/platform/win/window.cpp src/platform/linux/window.cpp src/platform/mac/window.mm src/tests/overlay_tests.cpp -p build/linux --config="{}"` *(fails: missing compilation database and headers)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b30e9198832586dfe5ab9519e945