### PR TITLE
Expose user config path and format log utility

### DIFF
--- a/src/app/config.h
+++ b/src/app/config.h
@@ -48,10 +48,10 @@ public:
 
   void reload();
   std::condition_variable &reload_cv() { return reload_cv_; }
+  static std::filesystem::path user_config_path();
 
 private:
   void load(std::unique_lock<std::shared_mutex> &lock);
-  static std::filesystem::path user_config_path();
 
   mutable std::shared_mutex mutex_;
   std::filesystem::path config_path_;

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -12,8 +12,8 @@ void init_logging(std::string_view level, std::size_t queue_size, std::size_t wo
   if (!logger) {
     spdlog::init_thread_pool(queue_size, worker_count);
     auto path = file_path.value_or("lizard.log");
-    logger = spdlog::rotating_logger_mt<spdlog::async_factory>(
-        "lizard", path.string(), 1024 * 1024 * 5, 3);
+    logger = spdlog::rotating_logger_mt<spdlog::async_factory>("lizard", path.string(),
+                                                               1024 * 1024 * 5, 3);
   }
   spdlog::set_default_logger(logger);
   auto lvl = spdlog::level::from_str(std::string(level));


### PR DESCRIPTION
## Summary
- make `Config::user_config_path` public so main can reference the user config file
- run clang-format on logging utility to satisfy style checks

## Testing
- `clang-format --dry-run --Werror $(git ls-files '*.cpp' '*.h' '*.hpp')`  
- `clang-tidy -p build/linux --config-file=/dev/null src/util/log.cpp` *(fails: unsupported format macros in spdlog)*  
- `cmake --build build/linux` *(fails: GTK status icon APIs deprecated; miniaudio incomplete types)*

------
https://chatgpt.com/codex/tasks/task_e_68c304d2f5b48325916ae3eb5c6a70d5