### PR TITLE
Limit badge spawns per second

### DIFF
--- a/src/tests/overlay_tests.cpp
+++ b/src/tests/overlay_tests.cpp
@@ -203,3 +203,14 @@ TEST_CASE("cursor_follow strategy uses provided coordinates", "[overlay]") {
   REQUIRE(b.x == Approx(0.25f));
   REQUIRE(b.y == Approx(0.75f));
 }
+
+TEST_CASE("badge spawns respect per-second limit", "[overlay]") {
+  Config cfg(std::filesystem::temp_directory_path());
+  cfg.badges_per_second_max_ = 2;
+  Overlay ov;
+  ov.init(cfg);
+  ov.spawn_badge(0, 0.0f, 0.0f);
+  ov.spawn_badge(0, 0.0f, 0.0f);
+  ov.spawn_badge(0, 0.0f, 0.0f);
+  REQUIRE(OverlayTestAccess::badges(ov).size() == 2);
+}


### PR DESCRIPTION
## Summary
- track recent badge spawn timestamps in overlay
- prevent new badges when spawns exceed configured per-second rate
- add unit test for badge spawn rate limiting

## Testing
- `clang-format --dry-run --Werror src/overlay/overlay.cpp src/tests/overlay_tests.cpp`
- `cmake -S . -B build` *(passes after installing dependencies)*
- `cmake --build build --target overlay_tests` *(passes)*
- `ctest --test-dir build -R overlay` *(fails: overlay_select SegFault)*

------
https://chatgpt.com/codex/tasks/task_e_68c310109f7c8325b8730ec2d14b49e4