### PR TITLE
ci: install prerequisites for lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install clang-tidy
+      - name: Setup prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-tidy
+          sudo apt-get install -y ninja-build xorg-dev libxi-dev libxrandr-dev libxinerama-dev libxcursor-dev libx11-dev libxext-dev libasound2-dev libgtk-3-dev clang-tidy
       - name: Configure
         run: cmake --preset linux
       - name: clang-tidy


### PR DESCRIPTION
## Summary
- install required build packages before lint job invokes CMake

## Testing
- `./actionlint .github/workflows/ci.yml`
- `cmake --preset linux -DLIZARD_EMBED_ASSETS=ON` *(fails: gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c34182cf1c8325b402ebc12690e789