### PR TITLE
Route badge spawns through a thread-safe queue

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
               bx = cx;
               by = cy;
             }
-            overlay.spawn_badge(bx, by);
+            overlay.enqueue_spawn(bx, by);
           }
         }
       },


### PR DESCRIPTION
## Summary
- add a mutex-protected queue to Overlay for cross-thread badge spawn requests
- process queued spawn requests on the overlay thread each frame before updating badges
- update the keyboard hook callback to enqueue spawn requests instead of spawning badges directly

## Testing
- `cmake -S . -B build -G Ninja` *(terminated after hanging while fetching external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_69069064aa6083258716b95a5bd95310