### PR TITLE
Add caret-aware badge spawning and monitor-weighted placement

### DIFF
--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -135,7 +135,12 @@ void Config::load(std::unique_lock<std::shared_mutex> &lock) {
     exclude_processes_ = j.value("exclude_processes", std::vector<std::string>{});
     ignore_injected_ = j.value("ignore_injected", true);
     audio_backend_ = j.value("audio_backend", std::string("miniaudio"));
-    badge_spawn_strategy_ = j.value("badge_spawn_strategy", std::string("random_screen"));
+    auto strategy_in = j.value("badge_spawn_strategy", std::string("random_screen"));
+    if (strategy_in != "random_screen" && strategy_in != "near_caret") {
+      spdlog::warn("Unknown badge_spawn_strategy ({}); defaulting to random_screen", strategy_in);
+      strategy_in = "random_screen";
+    }
+    badge_spawn_strategy_ = std::move(strategy_in);
     fps_mode_ = j.value("fps_mode", std::string("auto"));
     fps_fixed_ = clamp_nonneg(j.value("fps_fixed", 60), "fps_fixed");
     if (fps_fixed_ <= 0) {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -252,14 +252,7 @@ int main(int argc, char **argv) {
             if (!muted.load()) {
               engine.play();
             }
-            float bx = 0.0f;
-            float by = 0.0f;
-            if (cfg.badge_spawn_strategy() == "cursor_follow") {
-              auto [cx, cy] = lizard::platform::cursor_pos();
-              bx = cx;
-              by = cy;
-            }
-            overlay.enqueue_spawn(bx, by);
+            overlay.enqueue_spawn(0.0f, 0.0f);
           }
         }
       },

--- a/src/platform/window.hpp
+++ b/src/platform/window.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <optional>
 #ifdef _WIN32
 #include <windows.h>
 #elif defined(__linux__)
@@ -38,6 +39,7 @@ void destroy_window(Window &window);
 void poll_events(Window &window);
 bool fullscreen_window_present();
 std::pair<float, float> cursor_pos();
+std::optional<std::pair<float, float>> caret_pos();
 void make_context_current(Window &window);
 void clear_current_context(Window &window);
 void swap_buffers(Window &window);


### PR DESCRIPTION
## Summary
- validate `badge_spawn_strategy` against `random_screen`/`near_caret` and simplify the enqueue logic
- add platform caret helpers and update the overlay to use monitor-aware randomness with a per-display inset
- extend the overlay tests to cover both spawn strategies with injectable caret/monitor data

## Testing
- cmake --preset linux *(fails: missing gtk+-3.0 development package)*

------
https://chatgpt.com/codex/tasks/task_e_6906aab38de483258fa7223e249c76a9